### PR TITLE
devkitA64 alpha 5 updates (locks, TLS, etc) {TEST BEFORE MERGE}

### DIFF
--- a/buildscripts/lib/switch.specs
+++ b/buildscripts/lib/switch.specs
@@ -1,7 +1,7 @@
 %rename link                old_link
 
 *link:
-%(old_link) -T switch.ld%s -pie --gc-sections -z text
+%(old_link) -T switch.ld%s -pie --gc-sections -z text -z nodynamic-undefined-weak
 
 *startfile:
 switch_crt0%O%s crti%O%s crtbegin%O%s

--- a/nx/Makefile
+++ b/nx/Makefile
@@ -32,7 +32,7 @@ INCLUDES	:=	include
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-march=armv8-a -fPIC
+ARCH	:=	-march=armv8-a -mtp=soft -fPIC
 
 CFLAGS	:=	-g -Wall -Werror \
 			-ffunction-sections \

--- a/nx/include/switch/kernel/mutex.h
+++ b/nx/include/switch/kernel/mutex.h
@@ -1,13 +1,9 @@
 // Copyright 2017 plutoo
-typedef struct {
-    u32 Tag;
-} Mutex;
+#pragma once
+#include <sys/lock.h>
 
-typedef struct {
-    u32    Owner;
-    Mutex  Lock;
-    size_t Count;
-} RMutex;
+typedef _LOCK_T Mutex;
+typedef _LOCK_RECURSIVE_T RMutex;
 
 void mutexLock(Mutex* m);
 void mutexUnlock(Mutex* m);

--- a/nx/include/switch/kernel/mutex.h
+++ b/nx/include/switch/kernel/mutex.h
@@ -5,8 +5,20 @@
 typedef _LOCK_T Mutex;
 typedef _LOCK_RECURSIVE_T RMutex;
 
+static inline void mutexInit(Mutex* m)
+{
+    *m = 0;
+}
+
 void mutexLock(Mutex* m);
 void mutexUnlock(Mutex* m);
+
+static inline void rmutexInit(RMutex* m)
+{
+    m->lock = 0;
+    m->thread_tag = 0;
+    m->counter = 0;
+}
 
 void rmutexLock(RMutex* m);
 void rmutexUnlock(RMutex* m);

--- a/nx/include/switch/kernel/thread.h
+++ b/nx/include/switch/kernel/thread.h
@@ -1,7 +1,5 @@
 typedef struct {
     Handle     handle;
-    ThreadFunc entry;
-    void*      arg;
     void*      stack_mem;
     void*      stack_mirror;
     size_t     stack_sz;

--- a/nx/include/switch/result.h
+++ b/nx/include/switch/result.h
@@ -29,4 +29,5 @@
 #define LIBNX_NOTFOUND       8
 #define LIBNX_IOERROR        9
 #define LIBNX_BADINPUT       10
+#define LIBNX_BADREENT       11
 #define LIBNX_PARCEL_ERRBASE 100

--- a/nx/include/switch/services/fatal.h
+++ b/nx/include/switch/services/fatal.h
@@ -1,1 +1,1 @@
-void fatalSimple(Result err);
+__attribute__((noreturn)) void fatalSimple(Result err);

--- a/nx/source/internal.h
+++ b/nx/source/internal.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <sys/reent.h>
+#include <switch.h>
+
+#define THREADVARS_MAGIC 0x21545624 // !TV$
+
+// This structure is exactly 0x20 bytes, if more is needed modify getThreadVars() below
+typedef struct {
+    // Magic value used to check if the struct is initialized
+    u32 magic;
+
+    // Pointer to the current thread (if exists)
+    Thread* thread_ptr;
+
+    // Pointer to this thread's newlib state
+    struct _reent* reent;
+
+    // Pointer to this thread's thread-local segment
+    void* tls_tp; // !! Offset needs to be TLS+0x1F8 for __aarch64_read_tp !!
+} ThreadVars;
+
+static inline ThreadVars* getThreadVars(void) {
+    return (ThreadVars*)((u8*)armGetTls() + 0x1E0);
+}

--- a/nx/source/kernel/thread.c
+++ b/nx/source/kernel/thread.c
@@ -8,6 +8,7 @@ extern const u8 __tdata_lma_end[];
 extern u8 __tls_start[];
 extern u8 __tls_end[];
 
+// Thread creation args; keep this struct's size 16-byte aligned
 typedef struct {
     Thread*        t;
     ThreadFunc     entry;
@@ -34,7 +35,7 @@ Result threadCreate(
     Thread* t, ThreadFunc entry, void* arg, size_t stack_sz, int prio,
     int cpuid)
 {
-    stack_sz = (stack_sz+0xF) &~ 0xF;
+    stack_sz = (stack_sz+0xFFF) &~ 0xFFF;
 
     Result rc = 0;
     size_t reent_sz = (sizeof(struct _reent)+0xF) &~ 0xF;

--- a/nx/source/services/fatal.c
+++ b/nx/source/services/fatal.c
@@ -36,4 +36,5 @@ void fatalSimple(Result err) {
     }
 
     ((void(*)())0xBADC0DE)();
+	__builtin_unreachable();
 }

--- a/nx/source/services/fatal.c
+++ b/nx/source/services/fatal.c
@@ -36,5 +36,5 @@ void fatalSimple(Result err) {
     }
 
     ((void(*)())0xBADC0DE)();
-	__builtin_unreachable();
+    __builtin_unreachable();
 }

--- a/nx/source/system/init.c
+++ b/nx/source/system/init.c
@@ -63,7 +63,7 @@ void __attribute__((weak)) __libnx_init(void)
     __libc_init_array();
 }
 
-void __attribute__((weak)) NORETURN __libnx_exit(void)
+void __attribute__((weak)) NORETURN __libnx_exit(int rc)
 {
     // Call destructors.
     void __libc_fini_array(void);

--- a/nx/source/system/newlib.c
+++ b/nx/source/system/newlib.c
@@ -4,15 +4,15 @@
 #include <sys/lock.h>
 #include <sys/reent.h>
 
-void __attribute__((weak)) NORETURN __libnx_exit(void);
-
-
-static void NORETURN _ExitImpl(int rc) {
-    __libnx_exit();
-}
+void __attribute__((weak)) NORETURN __libnx_exit(int rc);
 
 void newlibSetup() {
-    void exitImpl(int rc);
-    __syscalls.exit = _ExitImpl;
+    // Register newlib syscalls
+    __syscalls.exit = __libnx_exit;
 
+    // Register locking syscalls
+    __syscalls.lock_acquire           = mutexLock;
+    __syscalls.lock_release           = mutexUnlock;
+    __syscalls.lock_acquire_recursive = rmutexLock;
+    __syscalls.lock_release_recursive = rmutexUnlock;
 }

--- a/nx/source/system/newlib.c
+++ b/nx/source/system/newlib.c
@@ -13,10 +13,8 @@ extern u8 __tls_start[];
 
 static struct _reent* __libnx_get_reent() {
     ThreadVars* tv = getThreadVars();
-    if (tv->magic != THREADVARS_MAGIC) {
+    if (tv->magic != THREADVARS_MAGIC)
         fatalSimple(MAKERESULT(MODULE_LIBNX, LIBNX_BADREENT));
-        for (;;);
-    }
     return tv->reent;
 }
 

--- a/nx/source/system/newlib.c
+++ b/nx/source/system/newlib.c
@@ -11,8 +11,10 @@ void newlibSetup() {
     __syscalls.exit = __libnx_exit;
 
     // Register locking syscalls
+    __syscalls.lock_init              = mutexInit;
     __syscalls.lock_acquire           = mutexLock;
     __syscalls.lock_release           = mutexUnlock;
+    __syscalls.lock_init_recursive    = rmutexInit;
     __syscalls.lock_acquire_recursive = rmutexLock;
     __syscalls.lock_release_recursive = rmutexUnlock;
 }

--- a/nx/source/system/newlib.c
+++ b/nx/source/system/newlib.c
@@ -3,12 +3,27 @@
 #include <sys/time.h>
 #include <sys/lock.h>
 #include <sys/reent.h>
+#include "../internal.h"
 
 void __attribute__((weak)) NORETURN __libnx_exit(int rc);
 
+extern const u8 __tdata_lma[];
+extern const u8 __tdata_lma_end[];
+extern u8 __tls_start[];
+
+static struct _reent* __libnx_get_reent() {
+    ThreadVars* tv = getThreadVars();
+    if (tv->magic != THREADVARS_MAGIC) {
+        fatalSimple(MAKERESULT(MODULE_LIBNX, LIBNX_BADREENT));
+        for (;;);
+    }
+    return tv->reent;
+}
+
 void newlibSetup() {
     // Register newlib syscalls
-    __syscalls.exit = __libnx_exit;
+    __syscalls.exit     = __libnx_exit;
+    __syscalls.getreent = __libnx_get_reent;
 
     // Register locking syscalls
     __syscalls.lock_init              = mutexInit;
@@ -17,4 +32,15 @@ void newlibSetup() {
     __syscalls.lock_init_recursive    = rmutexInit;
     __syscalls.lock_acquire_recursive = rmutexLock;
     __syscalls.lock_release_recursive = rmutexUnlock;
+
+    // Initialize thread vars for the main thread
+    ThreadVars* tv = getThreadVars();
+    tv->magic      = THREADVARS_MAGIC;
+    tv->thread_ptr = NULL;
+    tv->reent      = _impure_ptr;
+    tv->tls_tp     = __tls_start-2*sizeof(void*); // subtract size of Thread Control Block (TCB)
+
+    u32 tls_size = __tdata_lma_end - __tdata_lma;
+    if (tls_size)
+        memcpy(__tls_start, __tdata_lma, tls_size);
 }

--- a/nx/source/system/readtp.s
+++ b/nx/source/system/readtp.s
@@ -1,0 +1,10 @@
+	.section .text.__aarch64_read_tp, "ax", %progbits
+	.global __aarch64_read_tp
+	.type __aarch64_read_tp, %function
+	.align 2
+	.cfi_startproc
+__aarch64_read_tp:
+	mrs x0, tpidrro_el0
+	ldr x0, [x0, #0x1F8]
+	ret
+	.cfi_endproc


### PR DESCRIPTION
- [x] Using `-z nodynamic-undefined-weak` in linker options to remove dynamic lookup of undefined weak symbols (reduces unneeded bloat in generated binaries)
- [x] Add `-mtp=soft` to ARCH setting in makefile (*this change needs to be done in all projects including the switch examples*, I'll PR that later)
- [x] Integrate newlib locks with libnx (R)Mutex code
- [x] Add newlib reent support to libnx threads
- [x] Add TLS segment support to libnx threads

All of this is now done, however it's completely untested by me, since I can't run switch code (yet?)
Please test before merging.