### PR TITLE
elf2nro tweaks

### DIFF
--- a/crt0/switch_crt0.s
+++ b/crt0/switch_crt0.s
@@ -3,8 +3,10 @@
 
 _start:
     bl startup
+    .word 0
     .ascii "HOMEBREW"
 
+.org _start+0x80
 startup:
     // get aslr base
     sub  x28, x30, #4

--- a/tools/elf2nro.c
+++ b/tools/elf2nro.c
@@ -163,8 +163,7 @@ int main(int argc, char* argv[]) {
         fwrite(buf[i], nro_hdr.Segments[i].Size, 1, out);
     }
 
-    fseek(out, 0, SEEK_SET);
-    fwrite(&nro_start, sizeof(nro_start), 1, out);
+    fseek(out, sizeof(nro_start), SEEK_SET);
     fwrite(&nro_hdr, sizeof(nro_hdr), 1, out);
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
Did some more testing (and forgot to commit some code...), the RX+R+RW sections are guaranteed to be located in sequence, so it's best to use the vaddr as the file writing location. ~~With the current crt0, however, this causes the NRO0 header to overwrite some of .text, can be avoided with some padding though.~~ crt0 has been adjusted to account for the NRO header.