### PR TITLE
Add bsdSendTo and bsdSetSockOpt

### DIFF
--- a/nx/include/switch/services/bsd.h
+++ b/nx/include/switch/services/bsd.h
@@ -1,21 +1,3 @@
-Result bsdInitialize(TransferMemory* tmem);
-int bsdGetErrno();
-int bsdConnect(int sockfd, void* addr, u32 addrlen);
-int bsdSocket(int domain, int type, int protocol);
-int bsdBind(int sockfd, void* addr, u32 addrlen);
-int bsdListen(int sockfd, int backlog);
-int bsdSend(int sockfd, void* buffer, size_t length, int flags);
-int bsdRecv(int sockfd, void* buffer, size_t length, int flags);
-int bsdWrite(int sockfd, void* buffer, size_t length);
-
-#define BSD_AF_INET 2
-#define BSD_AF_INET6 10
-
-#define BSD_SOCK_STREAM 1
-#define BSD_SOCK_DGRAM 2
-
-#define BSD_MSG_RECV_ALL 0x40
-
 struct bsd_sockaddr_in {
     u8  sin_len;
     u8  sin_family;
@@ -23,3 +5,27 @@ struct bsd_sockaddr_in {
     u32 sin_addr;
     u8  sin_zero[8];
 };
+
+Result bsdInitialize(TransferMemory* tmem);
+int bsdGetErrno();
+int bsdConnect(int sockfd, void* addr, u32 addrlen);
+int bsdSocket(int domain, int type, int protocol);
+int bsdBind(int sockfd, void* addr, u32 addrlen);
+int bsdListen(int sockfd, int backlog);
+int bsdSend(int sockfd, void* buffer, size_t length, int flags);
+int bsdSendTo(int sockfd, void* buffer, size_t length, int flags, const struct bsd_sockaddr_in *dest_addr, size_t dest_len);
+int bsdRecv(int sockfd, void* buffer, size_t length, int flags);
+int bsdSetSockOpt(int sockfd, int level, int option_name, const void *option_value, size_t option_size);
+int bsdWrite(int sockfd, void* buffer, size_t length);
+
+#define BSD_AF_INET 2
+#define BSD_AF_INET6 10
+
+#define BSD_IPPROTO_IP 0
+#define BSD_IPPROTO_TCP 6
+#define BSD_IPPROTO_UDP 17
+
+#define BSD_SOCK_STREAM 1
+#define BSD_SOCK_DGRAM 2
+
+#define BSD_MSG_RECV_ALL 0x40


### PR DESCRIPTION
bsdSendTo definitely works, bsdSetSockOpt I haven't gotten any returns in Errno except 22 (Invalid argument), but it's not erroring from IPC at least. I was testing with UDP though, wanted to set SO_BROADCAST but maybe it's just not supported.