### PR TITLE
vi:m ManagedLayer support

### DIFF
--- a/nx/include/switch/services/vi.h
+++ b/nx/include/switch/services/vi.h
@@ -38,6 +38,7 @@ Handle viGetSession_IHOSBinderDriverIndirect(void);
 
 Result viOpenDisplay(const char *DisplayName, ViDisplay *display);
 Result viCloseDisplay(ViDisplay *display);
+Result viCreateManagedLayer(const ViDisplay *display, u32 LayerFlags, u64 AppletResourceUserId, u64 *layer_id);
 Result viOpenLayer(u8 NativeWindow[0x100], u64 *NativeWindow_Size, const ViDisplay *display, ViLayer *layer, u32 LayerFlags, u64 LayerId);
 Result viCloseLayer(ViLayer *layer);
 

--- a/nx/source/gfx/gfx.c
+++ b/nx/source/gfx/gfx.c
@@ -313,7 +313,7 @@ void gfxInitDefault(void)
         break;
     }
 
-    Result rc = _gfxInit(ViLayerFlags_Default, "Default", ViLayerFlags_Default, 0, nv_servicetype, 0x300000);
+    Result rc = _gfxInit(ViServiceType_Default, "Default", ViLayerFlags_Default, 0, nv_servicetype, 0x300000);
     if (R_FAILED(rc)) fatalSimple(rc);
 }
 

--- a/nx/source/services/vi.c
+++ b/nx/source/services/vi.c
@@ -249,7 +249,7 @@ Result viCloseDisplay(ViDisplay *display) {
     return rc;
 }
 
-static Result _viCreateManagedLayer(const ViDisplay *display, u32 LayerFlags, u64 AppletResourceUserId, u64 *layer_id) {
+Result viCreateManagedLayer(const ViDisplay *display, u32 LayerFlags, u64 AppletResourceUserId, u64 *layer_id) {
     IpcCommand c;
     ipcInitialize(&c);
 
@@ -396,8 +396,7 @@ Result viOpenLayer(u8 NativeWindow[0x100], u64 *NativeWindow_Size, const ViDispl
     }
     else {
         if (layer_id==0) {
-            rc = _viCreateManagedLayer(display, LayerFlags, AppletResourceUserId, &layer_id);
-            if (R_FAILED(rc)) rc = appletCreateManagedDisplayLayer(&layer_id);
+            rc = appletCreateManagedDisplayLayer(&layer_id);
 
             if (R_FAILED(rc)) return rc;
         }


### PR DESCRIPTION
vi:m is able to create its own managed layers without AppletAE/AppletAO. Also fixed a typo in gfx.c.