### PR TITLE
default icon now included with libnx on make install

### DIFF
--- a/nx/Makefile
+++ b/nx/Makefile
@@ -93,7 +93,7 @@ export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 all: lib/libnx.a lib/libnxd.a
 
 dist-bin: all
-	@tar --exclude=*~ -cjf libnx-$(VERSION).tar.bz2 include lib
+	@tar --exclude=*~ -cjf libnx-$(VERSION).tar.bz2 include lib default_icon.jpg
 
 dist-src:
 	@tar --exclude=*~ -cjf libnx-src-$(VERSION).tar.bz2 include source data Makefile # Doxyfile Doxyfile.internal


### PR DESCRIPTION
When using make install on libnx, it doesn't include the default icon when putting the libnx files in a .tar.bz2. This causes compiling on any libnx examples to error saying that the default icon couldn't be found.