### PR TITLE
usb_comms: Correct scenarios when freeing the endpoint out buffer

### DIFF
--- a/nx/source/runtime/devices/usb_comms.c
+++ b/nx/source/runtime/devices/usb_comms.c
@@ -44,15 +44,11 @@ Result usbCommsInitialize(void)
         if (R_FAILED(ret)) {
             usbDsExit();
 
-            if (g_usbComms_endpoint_in_buffer) {
-                free(g_usbComms_endpoint_in_buffer);
-                g_usbComms_endpoint_in_buffer = NULL;
-            }
+            free(g_usbComms_endpoint_in_buffer);
+            g_usbComms_endpoint_in_buffer = NULL;
 
-            if (g_usbComms_endpoint_out) {
-                free(g_usbComms_endpoint_out_buffer);
-                g_usbComms_endpoint_out_buffer = NULL;
-            }
+            free(g_usbComms_endpoint_out_buffer);
+            g_usbComms_endpoint_out_buffer = NULL;
         }
     }
     else {
@@ -75,15 +71,11 @@ void usbCommsExit(void)
     g_usbComms_endpoint_in = NULL;
     g_usbComms_endpoint_out = NULL;
 
-    if (g_usbComms_endpoint_in_buffer) {
-        free(g_usbComms_endpoint_in_buffer);
-        g_usbComms_endpoint_in_buffer = NULL;
-    }
+    free(g_usbComms_endpoint_in_buffer);
+    g_usbComms_endpoint_in_buffer = NULL;
 
-    if (g_usbComms_endpoint_out) {
-        free(g_usbComms_endpoint_out_buffer);
-        g_usbComms_endpoint_out_buffer = NULL;
-    }
+    free(g_usbComms_endpoint_out_buffer);
+    g_usbComms_endpoint_out_buffer = NULL;
 }
 
 static Result _usbCommsInit(void)


### PR DESCRIPTION
Previously g_usbComms_endpoint_out_buffer wouldnt be freed in usbCommsExit, as g_usbComms_endpoint_out would be set to NULL before the conditional check.

I've opted to remove the checks for null before calling free, since it's unnecessary, but can add them back with the corrected conditional if that's preferable.