### PR TITLE
hid: Add hidJoystickRead

### DIFF
--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -277,6 +277,14 @@ typedef enum
 
 typedef enum
 {
+    JOYSTICK_LEFT  = 0,
+    JOYSTICK_RIGHT = 1,
+
+    JOYSTICK_NUM_STICKS = 2,
+} HidControllerJoystick;
+
+typedef enum
+{
     CONTROLLER_STATE_CONNECTED = BIT(0),
     CONTROLLER_STATE_WIRED     = BIT(1),
 } HidControllerConnectionState;
@@ -304,6 +312,15 @@ typedef struct touchPosition
     u32 dy;
     u32 angle;
 } touchPosition;
+
+typedef struct circlePosition
+{
+    s32 dx;
+    s32 dy;
+} circlePosition;
+
+#define JOYSTICK_MAX (0x8000)
+#define JOYSTICK_MIN (-0x8000)
 
 // End enums and output structs
 
@@ -463,10 +480,7 @@ typedef struct HidControllerInputEntry
     u64 timestamp;
     u64 timestamp_2;
     u64 buttons;
-    u32 joystickLeftX;
-    u32 joystickLeftY;
-    u32 joystickRightX;
-    u32 joystickRightY;
+    circlePosition joysticks[JOYSTICK_NUM_STICKS];
     u64 connectionState;
 } HidControllerInputEntry;
 static_assert(sizeof(HidControllerInputEntry) == 0x30, "Hid controller input entry structure has incorrect size");
@@ -540,3 +554,5 @@ bool hidKeyboardUp(HidKeyboardScancode key);
 
 u32 hidTouchCount(void);
 void hidTouchRead(touchPosition *pos, u32 point_id);
+
+void hidJoystickRead(circlePosition *pos, HidControllerID id, HidControllerJoystick stick);

--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -313,11 +313,11 @@ typedef struct touchPosition
     u32 angle;
 } touchPosition;
 
-typedef struct joystickPosition
+typedef struct JoystickPosition
 {
     s32 dx;
     s32 dy;
-} joystickPosition;
+} JoystickPosition;
 
 #define JOYSTICK_MAX (0x8000)
 #define JOYSTICK_MIN (-0x8000)
@@ -480,7 +480,7 @@ typedef struct HidControllerInputEntry
     u64 timestamp;
     u64 timestamp_2;
     u64 buttons;
-    joystickPosition joysticks[JOYSTICK_NUM_STICKS];
+    JoystickPosition joysticks[JOYSTICK_NUM_STICKS];
     u64 connectionState;
 } HidControllerInputEntry;
 static_assert(sizeof(HidControllerInputEntry) == 0x30, "Hid controller input entry structure has incorrect size");
@@ -555,4 +555,4 @@ bool hidKeyboardUp(HidKeyboardScancode key);
 u32 hidTouchCount(void);
 void hidTouchRead(touchPosition *pos, u32 point_id);
 
-void hidJoystickRead(joystickPosition *pos, HidControllerID id, HidControllerJoystick stick);
+void hidJoystickRead(JoystickPosition *pos, HidControllerID id, HidControllerJoystick stick);

--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -313,11 +313,11 @@ typedef struct touchPosition
     u32 angle;
 } touchPosition;
 
-typedef struct circlePosition
+typedef struct joystickPosition
 {
     s32 dx;
     s32 dy;
-} circlePosition;
+} joystickPosition;
 
 #define JOYSTICK_MAX (0x8000)
 #define JOYSTICK_MIN (-0x8000)
@@ -480,7 +480,7 @@ typedef struct HidControllerInputEntry
     u64 timestamp;
     u64 timestamp_2;
     u64 buttons;
-    circlePosition joysticks[JOYSTICK_NUM_STICKS];
+    joystickPosition joysticks[JOYSTICK_NUM_STICKS];
     u64 connectionState;
 } HidControllerInputEntry;
 static_assert(sizeof(HidControllerInputEntry) == 0x30, "Hid controller input entry structure has incorrect size");
@@ -555,4 +555,4 @@ bool hidKeyboardUp(HidKeyboardScancode key);
 u32 hidTouchCount(void);
 void hidTouchRead(touchPosition *pos, u32 point_id);
 
-void hidJoystickRead(circlePosition *pos, HidControllerID id, HidControllerJoystick stick);
+void hidJoystickRead(joystickPosition *pos, HidControllerID id, HidControllerJoystick stick);

--- a/nx/source/services/hid.c
+++ b/nx/source/services/hid.c
@@ -327,7 +327,7 @@ void hidTouchRead(touchPosition *pos, u32 point_id) {
     }
 }
 
-void hidJoystickRead(joystickPosition *pos, HidControllerID id, HidControllerJoystick stick) {
+void hidJoystickRead(JoystickPosition *pos, HidControllerID id, HidControllerJoystick stick) {
     if (id == CONTROLLER_P1_AUTO) return hidJoystickRead(pos, g_controllerP1AutoID, stick);
 
     if (pos) {

--- a/nx/source/services/hid.c
+++ b/nx/source/services/hid.c
@@ -327,7 +327,7 @@ void hidTouchRead(touchPosition *pos, u32 point_id) {
     }
 }
 
-void hidJoystickRead(circlePosition *pos, HidControllerID id, HidControllerJoystick stick) {
+void hidJoystickRead(joystickPosition *pos, HidControllerID id, HidControllerJoystick stick) {
     if (id == CONTROLLER_P1_AUTO) return hidJoystickRead(pos, g_controllerP1AutoID, stick);
 
     if (pos) {

--- a/nx/source/services/hid.c
+++ b/nx/source/services/hid.c
@@ -327,6 +327,22 @@ void hidTouchRead(touchPosition *pos, u32 point_id) {
     }
 }
 
+void hidJoystickRead(circlePosition *pos, HidControllerID id, HidControllerJoystick stick) {
+    if (id == CONTROLLER_P1_AUTO) return hidJoystickRead(pos, g_controllerP1AutoID, stick);
+
+    if (pos) {
+        if (id < 0 || id > 9 || stick >= JOYSTICK_NUM_STICKS) {
+            memset(pos, 0, sizeof(touchPosition));
+            return;
+        }
+
+        rwlockReadLock(&g_hidLock);
+        pos->dx = g_controllerEntries[id].joysticks[stick].dx;
+        pos->dy = g_controllerEntries[id].joysticks[stick].dy;
+        rwlockReadUnlock(&g_hidLock);
+    }
+}
+
 static Result _hidCreateAppletResource(Service* srv, Service* srv_out, u64 AppletResourceUserId) {
     IpcCommand c;
     ipcInitialize(&c);


### PR DESCRIPTION
Sample of usage:
```
JoystickPosition lStick;
JoystickPosition rStick;
float lStickX;
float lStickY;
float rStickX;
float rStickY;

while(appIsAliveOrSomething())
{
    hidScanInput();

    hidJoystickRead(&lStick, CONTROLLER_HANDHELD, JOYSTICK_LEFT);
    hidJoystickRead(&rStick, CONTROLLER_HANDHELD, JOYSTICK_RIGHT);

    lStickX = (float)lStick.dx / JOYSTICK_MAX;
    lStickY = (float)lStick.dy / JOYSTICK_MAX;
    rStickX = (float)rStick.dx / JOYSTICK_MAX;
    rStickY = (float)rStick.dy / JOYSTICK_MAX;
    printf("(%f, %f) (%f, %f)\n", lStickX, lStickY, rStickX, rStickY);
}
```

At the moment it still follows the ctrulib way where values are passed in raw (dx,dy are just s32s from -0x8000 to 0x8000), though some defines are provided for min/max values for conversion to float.