### PR TITLE
Make the bsd service work properly

### DIFF
--- a/nx/include/switch/services/bsd.h
+++ b/nx/include/switch/services/bsd.h
@@ -2,6 +2,21 @@
 #include <switch/types.h>
 #include <switch/kernel/tmem.h>
 
+/// Configuration structure for bsdInitalize
+typedef struct  {
+    u32 version;                ///< Observed 1 on 2.0 LibAppletWeb, 2 on 3.0.
+
+    u32 tcp_tx_buf_size;        ///< Size of the TCP transfer (send) buffer (initial or fixed).
+    u32 tcp_rx_buf_size;        ///< Size of the TCP recieve buffer (initial or fixed).
+    u32 tcp_tx_buf_max_size;    ///< Maximum size of the TCP transfer (send) buffer. If it is 0, the size of the buffer is fixed to its initial value.
+    u32 tcp_rx_buf_max_size;    ///< Maximum size of the TCP receive buffer. If it is 0, the size of the buffer is fixed to its initial value.
+
+    u32 udp_tx_buf_size;        ///< Size of the UDP transfer (send) buffer (typically 0x2400 bytes).
+    u32 udp_rx_buf_size;        ///< Size of the UDP receive buffer (typically 0xA500 bytes).
+
+    u32 sb_efficiency;          ///< Number of buffers for each socket (standard values range from 1 to 8).
+} BsdConfig;
+
 struct bsd_sockaddr_in {
     u8  sin_len;
     u8  sin_family;
@@ -10,21 +25,47 @@ struct bsd_sockaddr_in {
     u8  sin_zero[8];
 };
 
-Result bsdInitialize(TransferMemory* tmem);
+const BsdConfig *bsdGetDefaultConfig(void);
+Result bsdInitialize(TransferMemory* tmem, const BsdConfig *config);
 int bsdGetErrno(void);
-int bsdConnect(int sockfd, void* addr, u32 addrlen);
+int bsdConnect(int sockfd, const void* addr, u32 addrlen);
 int bsdSocket(int domain, int type, int protocol);
-int bsdBind(int sockfd, void* addr, u32 addrlen);
+int bsdBind(int sockfd, const void* addr, u32 addrlen);
 int bsdListen(int sockfd, int backlog);
-int bsdSend(int sockfd, void* buffer, size_t length, int flags);
-int bsdSendTo(int sockfd, void* buffer, size_t length, int flags, const struct bsd_sockaddr_in *dest_addr, size_t dest_len);
+int bsdSend(int sockfd, const void* buffer, size_t length, int flags);
+int bsdSendTo(int sockfd, const void* buffer, size_t length, int flags, const struct bsd_sockaddr_in *dest_addr, size_t dest_len);
 int bsdRecv(int sockfd, void* buffer, size_t length, int flags);
 int bsdSetSockOpt(int sockfd, int level, int option_name, const void *option_value, size_t option_size);
-int bsdWrite(int sockfd, void* buffer, size_t length);
+int bsdWrite(int sockfd, const void* buffer, size_t length);
+
+/**
+ * @brief Computes the minimal size of the transfer memory to be passed to @ref bsdInitalize.
+ *        Should the transfer memory be smaller than that, the BSD sockets service would only send
+ *        ZeroWindow packets (for TCP), resulting in a transfer rate not exceeding 1 byte/s.
+ * @param config Pointer to the BSD sockets service configuration.
+ */
+static inline size_t bsdGetTransferMemSizeForConfig(const BsdConfig *config)
+{
+    u32 tcp_tx_buf_max_size = config->tcp_tx_buf_max_size != 0 ? config->tcp_tx_buf_max_size : config->tcp_tx_buf_size;
+    u32 tcp_rx_buf_max_size = config->tcp_rx_buf_max_size != 0 ? config->tcp_rx_buf_max_size : config->tcp_rx_buf_size;
+    u32 sum = tcp_tx_buf_max_size + tcp_rx_buf_max_size + config->udp_tx_buf_size + config->udp_rx_buf_size;
+
+    sum = ((sum + 0xFFF) >> 12) << 12; // page round-up
+    return (size_t)(config->sb_efficiency * sum);
+}
+
+static inline size_t bsdGetTransferMemSizeForDefaultConfig(void)
+{
+    return bsdGetTransferMemSizeForConfig(bsdGetDefaultConfig());
+}
+
+static inline Result bsdInitializeDefault(TransferMemory* tmem)
+{
+    return bsdInitialize(tmem, bsdGetDefaultConfig());
+}
 
 #define BSD_AF_INET 2
 #define BSD_AF_INET6 10
-
 #define BSD_IPPROTO_IP 0
 #define BSD_IPPROTO_TCP 6
 #define BSD_IPPROTO_UDP 17

--- a/nx/include/switch/services/bsd.h
+++ b/nx/include/switch/services/bsd.h
@@ -26,7 +26,8 @@ struct bsd_sockaddr_in {
 };
 
 const BsdConfig *bsdGetDefaultConfig(void);
-Result bsdInitialize(TransferMemory* tmem, const BsdConfig *config);
+Result bsdInitialize(const BsdConfig *config);
+void bsdExit(void);
 int bsdGetErrno(void);
 int bsdConnect(int sockfd, const void* addr, u32 addrlen);
 int bsdSocket(int domain, int type, int protocol);
@@ -38,30 +39,9 @@ int bsdRecv(int sockfd, void* buffer, size_t length, int flags);
 int bsdSetSockOpt(int sockfd, int level, int option_name, const void *option_value, size_t option_size);
 int bsdWrite(int sockfd, const void* buffer, size_t length);
 
-/**
- * @brief Computes the minimal size of the transfer memory to be passed to @ref bsdInitalize.
- *        Should the transfer memory be smaller than that, the BSD sockets service would only send
- *        ZeroWindow packets (for TCP), resulting in a transfer rate not exceeding 1 byte/s.
- * @param config Pointer to the BSD sockets service configuration.
- */
-static inline size_t bsdGetTransferMemSizeForConfig(const BsdConfig *config)
+static inline Result bsdInitializeDefault(void)
 {
-    u32 tcp_tx_buf_max_size = config->tcp_tx_buf_max_size != 0 ? config->tcp_tx_buf_max_size : config->tcp_tx_buf_size;
-    u32 tcp_rx_buf_max_size = config->tcp_rx_buf_max_size != 0 ? config->tcp_rx_buf_max_size : config->tcp_rx_buf_size;
-    u32 sum = tcp_tx_buf_max_size + tcp_rx_buf_max_size + config->udp_tx_buf_size + config->udp_rx_buf_size;
-
-    sum = ((sum + 0xFFF) >> 12) << 12; // page round-up
-    return (size_t)(config->sb_efficiency * sum);
-}
-
-static inline size_t bsdGetTransferMemSizeForDefaultConfig(void)
-{
-    return bsdGetTransferMemSizeForConfig(bsdGetDefaultConfig());
-}
-
-static inline Result bsdInitializeDefault(TransferMemory* tmem)
-{
-    return bsdInitialize(tmem, bsdGetDefaultConfig());
+    return bsdInitialize(bsdGetDefaultConfig());
 }
 
 #define BSD_AF_INET 2

--- a/nx/include/switch/types.h
+++ b/nx/include/switch/types.h
@@ -73,4 +73,4 @@ typedef enum {
 #define DEPRECATED
 #endif
 
-#define INVALID_HANDLE ((Handle) -1)
+#define INVALID_HANDLE ((Handle) 0)

--- a/nx/source/runtime/env.c
+++ b/nx/source/runtime/env.c
@@ -30,7 +30,7 @@ void envSetup(void* ctx, Handle main_thread, LoaderReturnFn saved_lr)
     }
 
     // Detect NSO environment.
-    if (main_thread != INVALID_HANDLE)
+    if (main_thread != -1)
     {
         g_mainThreadHandle = main_thread;
         g_isNso = true;

--- a/nx/source/services/bsd.c
+++ b/nx/source/services/bsd.c
@@ -7,13 +7,17 @@
 #include <switch/kernel/shmem.h>
 #include <switch/kernel/rwlock.h>
 
+#define EPIPE 32
+
 static Service g_bsdSrv;
 static Service g_bsdMonitor;
 static u64 g_bsdClientPid = -1;
 static int g_Errno = 0;
 
+static TransferMemory g_bsdTmem;
+
 static const BsdConfig g_defaultBsdConfig = {
-    .version = 2,
+    .version = 1,
 
     .tcp_tx_buf_size        = 0x8000,
     .tcp_rx_buf_size        = 0x10000,
@@ -26,7 +30,20 @@ static const BsdConfig g_defaultBsdConfig = {
     .sb_efficiency = 4,
 };
 
-#define EPIPE 32
+/*
+    This function computes the minimal size of the transfer memory to be passed to @ref bsdInitalize.
+    Should the transfer memory be smaller than that, the BSD sockets service would only send
+    ZeroWindow packets (for TCP), resulting in a transfer rate not exceeding 1 byte/s.
+*/
+static size_t _bsdGetTransferMemSizeForConfig(const BsdConfig *config)
+{
+    u32 tcp_tx_buf_max_size = config->tcp_tx_buf_max_size != 0 ? config->tcp_tx_buf_max_size : config->tcp_tx_buf_size;
+    u32 tcp_rx_buf_max_size = config->tcp_rx_buf_max_size != 0 ? config->tcp_rx_buf_max_size : config->tcp_rx_buf_size;
+    u32 sum = tcp_tx_buf_max_size + tcp_rx_buf_max_size + config->udp_tx_buf_size + config->udp_rx_buf_size;
+
+    sum = ((sum + 0xFFF) >> 12) << 12; // page round-up
+    return (size_t)(config->sb_efficiency * sum);
+}
 
 static Result _bsdRegisterClient(Service* srv, TransferMemory* tmem, const BsdConfig *config, u64* pid_out) {
     IpcCommand c;
@@ -108,28 +125,43 @@ const BsdConfig *bsdGetDefaultConfig(void) {
     return &g_defaultBsdConfig;
 }
 
-Result bsdInitialize(TransferMemory* tmem, const BsdConfig *config) {
+Result bsdInitialize(const BsdConfig *config) {
     const char* bsd_srv = "bsd:s";
+
+    if(serviceIsActive(&g_bsdSrv) || serviceIsActive(&g_bsdMonitor))
+        return MAKERESULT(Module_Libnx, LibnxError_AlreadyInitialized);
+
     Result rc = smGetService(&g_bsdSrv, bsd_srv);
 
     if (R_FAILED(rc)) {
         bsd_srv = "bsd:u";
         rc = smGetService(&g_bsdSrv, bsd_srv);
     }
+    if(R_FAILED(rc)) goto error;
 
-    if (R_SUCCEEDED(rc)) {
-        rc = smGetService(&g_bsdMonitor, bsd_srv);
+    rc = smGetService(&g_bsdMonitor, bsd_srv);
+    if(R_FAILED(rc)) goto error;
 
-        if (R_SUCCEEDED(rc)) {
-            rc = _bsdRegisterClient(&g_bsdSrv, tmem, config, &g_bsdClientPid);
+    rc = tmemCreate(&g_bsdTmem, _bsdGetTransferMemSizeForConfig(config), 0);
+    if(R_FAILED(rc)) goto error;
 
-            if (R_SUCCEEDED(rc)) {
-                rc = _bsdStartMonitor(&g_bsdMonitor, g_bsdClientPid);
-            }
-        }
-    }
+    rc = _bsdRegisterClient(&g_bsdSrv, &g_bsdTmem, config, &g_bsdClientPid);
+    if(R_FAILED(rc)) goto error;
+
+    rc = _bsdStartMonitor(&g_bsdMonitor, g_bsdClientPid);
+    if(R_FAILED(rc)) goto error;
 
     return rc;
+
+error:
+    bsdExit();
+    return rc;
+}
+
+void bsdExit(void) {
+    serviceClose(&g_bsdMonitor);
+    serviceClose(&g_bsdSrv);
+    tmemClose(&g_bsdTmem);
 }
 
 int bsdGetErrno(void) {


### PR DESCRIPTION
This fixes the initalization of the BSD service(s). Without this commit, the bsd services wouldn't send or receive more than 1 byte/s using TCP, as it was issuing ZeroWindow (unbuffered) packets, symptom of a lack of memory.

The following helper functions have been added:

* ~~`bsdGetTransferMemSizeForConfig`, returning the minimal size needed for the transfer memory to be passed to `bsdInitalize` (using any size less than that will cause the abovementionned issue)~~
* `bsdGetDefaultConfig`, returning a reasonable default configuration for the developer to use
* `bsdInitalizeDefault`

The `bsd` service code now manages the transfer memory itself.
`bsdExit` has been added.

Some const-correctness issues have also been made.