### PR TITLE
Silence a few missing prototype warnings

### DIFF
--- a/nx/include/switch/gfx/buffer_producer.h
+++ b/nx/include/switch/gfx/buffer_producer.h
@@ -105,7 +105,7 @@ enum {
 };
 
 Result bufferProducerInitialize(Binder *session);
-void bufferProducerExit();
+void bufferProducerExit(void);
 
 Result bufferProducerRequestBuffer(s32 bufferIdx, bufferProducerGraphicBuffer *buf);
 Result bufferProducerDequeueBuffer(bool async, u32 width, u32 height, s32 format, u32 usage, s32 *buf, bufferProducerFence *fence);

--- a/nx/include/switch/services/acc.h
+++ b/nx/include/switch/services/acc.h
@@ -1,9 +1,10 @@
 #pragma once
 #include "../types.h"
+#include "sm.h"
 
 Result accountInitialize(void);
 void accountExit(void);
-Handle accountGetSessionService(void);
+Service* accountGetService(void);
 
 /// Get the userID for the currently active user. The output userID is only valid when the output account_selected==1, otherwise no user is currently selected.
 Result accountGetActiveUser(u128 *userID, bool *account_selected);

--- a/nx/source/gfx/nvgfx.c
+++ b/nx/source/gfx/nvgfx.c
@@ -57,7 +57,7 @@ extern size_t g_gfx_singleframebuf_size;
 
 Result _gfxGraphicBufferInit(s32 buf, u32 nvmap_handle);
 
-Result nvmapobjInitialize(nvmapobj *obj, size_t size) {
+static Result nvmapobjInitialize(nvmapobj *obj, size_t size) {
     Result rc=0;
 
     if(obj->initialized)return 0;
@@ -77,7 +77,7 @@ Result nvmapobjInitialize(nvmapobj *obj, size_t size) {
     return rc;
 }
 
-void nvmapobjClose(nvmapobj *obj) {
+static void nvmapobjClose(nvmapobj *obj) {
     if(!obj->initialized)return;
 
     if (obj->mem) {
@@ -88,13 +88,13 @@ void nvmapobjClose(nvmapobj *obj) {
     memset(obj, 0, sizeof(nvmapobj));
 }
 
-void nvmapobjCloseAll(void) {
+static void nvmapobjCloseAll(void) {
     u32 pos=0;
 
     for(pos=0; pos<sizeof(nvmap_objs)/sizeof(nvmapobj); pos++) nvmapobjClose(&nvmap_objs[pos]);
 }
 
-Result nvmapobjSetup(nvmapobj *obj, u32 heapmask, u32 flags, u32 align, u8 kind) {
+static Result nvmapobjSetup(nvmapobj *obj, u32 heapmask, u32 flags, u32 align, u8 kind) {
     Result rc=0;
 
     rc = nvioctlNvmap_Create(g_nvgfx_fd_nvmap, obj->mem_size, &obj->handle);

--- a/nx/source/kernel/random.c
+++ b/nx/source/kernel/random.c
@@ -65,7 +65,7 @@ static void _Round(u8 output[64], const u32 input[16])
 
 static const char sigma[16] = "expand 32-byte k";
 
-void chachaInit(ChaCha* x, const u8* key, const u8* iv)
+static void chachaInit(ChaCha* x, const u8* key, const u8* iv)
 {
     // Setup key.
     x->input[0]  = U8TO32_LITTLE(sigma + 0);
@@ -88,7 +88,7 @@ void chachaInit(ChaCha* x, const u8* key, const u8* iv)
     x->input[15] = U8TO32_LITTLE(iv + 4);
 }
 
-void chachaEncrypt(ChaCha* x, const u8* m, u8* c, size_t bytes)
+static void chachaEncrypt(ChaCha* x, const u8* m, u8* c, size_t bytes)
 {
     u8 output[64];
     int i;
@@ -123,7 +123,7 @@ static ChaCha g_chacha;
 static bool   g_randInit = false;
 static Mutex  g_randMutex;
 
-void _randomInit(void)
+static void _randomInit(void)
 {
     // Has already initialized?
     if (g_randInit)

--- a/nx/source/runtime/devices/console.c
+++ b/nx/source/runtime/devices/console.c
@@ -204,7 +204,7 @@ static inline void consolePosition(int x, int y) {
 }
 
 //---------------------------------------------------------------------------------
-ssize_t con_write(struct _reent *r,void *fd,const char *ptr, size_t len) {
+static ssize_t con_write(struct _reent *r,void *fd,const char *ptr, size_t len) {
 //---------------------------------------------------------------------------------
 
 	char chr;

--- a/nx/source/runtime/newlib.c
+++ b/nx/source/runtime/newlib.c
@@ -23,7 +23,7 @@ static struct _reent* __libnx_get_reent(void) {
     return tv->reent;
 }
 
-void newlibSetup() {
+void newlibSetup(void) {
     // Register newlib syscalls
     __syscalls.exit     = __libnx_exit;
     __syscalls.getreent = __libnx_get_reent;

--- a/nx/source/services/applet.c
+++ b/nx/source/services/applet.c
@@ -38,8 +38,6 @@ static bool g_appletNotifiedRunning = 0;
 
 static AppletHookCookie g_appletFirstHook;
 
-void appletExit(void);
-
 static Result _appletGetHandle(Service* srv, Handle* handle_out, u64 cmd_id);
 static Result _appletGetSession(Service* srv, Service* srv_out, u64 cmd_id);
 static Result _appletGetSessionProxy(Service* srv_out, u64 cmd_id, Handle prochandle, u8 *AppletAttribute);


### PR DESCRIPTION
These occur with a few other warning flags and figured I'd fix them, particularly because a function prototype was exposed in acc.h that doesn't have an implementation (`accountGetSessionService`).

If some others were actually intended to be exposed in headers, just let me know and I'll move them over as opposed to making them static.