### PR TITLE
hid: Improve heuristics for P1_AUTO to switch between controllers, add CONTROLLER_ANY

### DIFF
--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -310,7 +310,7 @@ typedef enum
     CONTROLLER_PLAYER_8 = 7,
     CONTROLLER_HANDHELD = 8,
     CONTROLLER_UNKNOWN  = 9,
-    CONTROLLER_P1_AUTO = 10, /// Not an actual HID-sysmodule ID. Only for hidKeys*(). Automatically uses CONTROLLER_PLAYER_1 when connected, otherwise uses CONTROLLER_HANDHELD.
+    CONTROLLER_P1_AUTO = 10, /// Not an actual HID-sysmodule ID. Only for hidKeys*(). Switches the commanding controller based on activity.
 } HidControllerID;
 
 typedef struct touchPosition

--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -310,7 +310,8 @@ typedef enum
     CONTROLLER_PLAYER_8 = 7,
     CONTROLLER_HANDHELD = 8,
     CONTROLLER_UNKNOWN  = 9,
-    CONTROLLER_P1_AUTO = 10, /// Not an actual HID-sysmodule ID. Only for hidKeys*(). Switches the commanding controller based on activity.
+    CONTROLLER_P1_AUTO = 10, /// Not an actual HID-sysmodule ID. Only for hidKeys*(). Switches the commanding controller between handheld and player 1 based on activity.
+    CONTROLLER_ANY     = 11, /// Not an actual HID-sysmodule ID. Only for hidKeys*(). Switches the commanding controller based on activity.
 } HidControllerID;
 
 typedef struct touchPosition

--- a/nx/source/services/hid.c
+++ b/nx/source/services/hid.c
@@ -207,26 +207,26 @@ void hidScanInput(void) {
             g_controllerTimestamps[i] = newInputEntry->timestamp;
 
             g_controllerHeld[i] |= g_controllerEntries[i].buttons;
-
-            if (g_controllerDown[i]) {
-                g_controllerHeldStartTime[i] = g_controllerTimestamps[i];
-            } else if (g_controllerUp[i]) {
-                g_controllerHeldStartTime[i] = 0;
-            }
-
-            bool sticksActive = (g_controllerEntries[i].joysticks[JOYSTICK_LEFT].dx
-                                 || g_controllerEntries[i].joysticks[JOYSTICK_RIGHT].dx
-                                 || g_controllerEntries[i].joysticks[JOYSTICK_LEFT].dy
-                                 || g_controllerEntries[i].joysticks[JOYSTICK_RIGHT].dy);
-            if (sticksActive && !g_controllerStickHeldStartTime[i]) {
-                g_controllerStickHeldStartTime[i] = g_controllerTimestamps[i];
-            } else if (!sticksActive && g_controllerStickHeldStartTime[i]){
-                g_controllerStickHeldStartTime[i] = 0;
-            }
         }
 
         g_controllerDown[i] = (~g_controllerOld[i]) & g_controllerHeld[i];
         g_controllerUp[i] = g_controllerOld[i] & (~g_controllerHeld[i]);
+
+        if (g_controllerDown[i]) {
+            g_controllerHeldStartTime[i] = g_controllerTimestamps[i];
+        } else if (g_controllerUp[i]) {
+            g_controllerHeldStartTime[i] = 0;
+        }
+
+        bool sticksActive = (g_controllerEntries[i].joysticks[JOYSTICK_LEFT].dx
+                             || g_controllerEntries[i].joysticks[JOYSTICK_RIGHT].dx
+                             || g_controllerEntries[i].joysticks[JOYSTICK_LEFT].dy
+                             || g_controllerEntries[i].joysticks[JOYSTICK_RIGHT].dy);
+        if (sticksActive && !g_controllerStickHeldStartTime[i]) {
+            g_controllerStickHeldStartTime[i] = g_controllerTimestamps[i];
+        } else if (!sticksActive && g_controllerStickHeldStartTime[i]){
+            g_controllerStickHeldStartTime[i] = 0;
+        }
     }
 
     // For P1_AUTO and ANY, newer inputs > older inputs


### PR DESCRIPTION
[video of new heuristics](https://www.youtube.com/watch?v=1aiY7mYiDbM)

Heuristics used are the same as those in the home menu and other Nintendo system applets; the active joystick and active buttons are split. The controller used for buttons is the controller with newer inputs, and the controller used for joysticks is the first controller to be using the joystick. This way joystick input doesn't suddenly change, but the newest button inputs are always retrieved. Digital joystick values fall under the category of buttons and not joysticks.

In order to keep track of which inputs are newer, any buttonDown will store a timestamp of how many samples a controller has had active inputs (and the same goes for joystick values).