### PR TITLE
use only one portlibs directory

### DIFF
--- a/nx/switch_rules
+++ b/nx/switch_rules
@@ -4,7 +4,7 @@ endif
 
 include $(DEVKITPRO)/devkitA64/base_rules
 
-PORTLIBS	:=	$(PORTLIBS_PATH)/switch $(PORTLIBS_PATH)/armv8-a
+PORTLIBS	:=	$(PORTLIBS_PATH)/switch
 
 LIBNX	?=	$(DEVKITPRO)/libnx
 


### PR DESCRIPTION
Compile options for switch are too specific to use for generic armv8-a 