### PR TITLE
add portlibs bin to path

### DIFF
--- a/nx/switch_rules
+++ b/nx/switch_rules
@@ -5,6 +5,7 @@ endif
 include $(DEVKITPRO)/devkitA64/base_rules
 
 PORTLIBS	:=	$(PORTLIBS_PATH)/switch
+PATH	:=	$(PORTLIBS)/bin:$(PATH)
 
 LIBNX	?=	$(DEVKITPRO)/libnx
 


### PR DESCRIPTION
Adding portlibs bin folder to path so the various config scripts can be used from standard Makefiles