### PR TITLE
fix stringop-truncation warnings

### DIFF
--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -242,7 +242,7 @@ fsdev_getfspath(struct _reent *r,
     return -1;
 
   memset(outpath, 0, FS_MAX_PATH);
-  memcpy(outpath, __fixedpath,FS_MAX_PATH);
+  memcpy(outpath, __fixedpath,FS_MAX_PATH-1);
   outpath[FS_MAX_PATH-1] = '\0';
 
   return 0;

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -199,7 +199,7 @@ fsdev_fixpath(struct _reent *r,
     strncpy(__fixedpath, path, PATH_MAX);
   else
   {
-    strncpy(__fixedpath, __cwd, PATH_MAX);
+    strcpy(__fixedpath, __cwd);
     strncat(__fixedpath, path, PATH_MAX - strlen(__cwd));
   }
 
@@ -242,7 +242,8 @@ fsdev_getfspath(struct _reent *r,
     return -1;
 
   memset(outpath, 0, FS_MAX_PATH);
-  strncpy(outpath, __fixedpath, FS_MAX_PATH);
+  memcpy(outpath, __fixedpath,FS_MAX_PATH);
+  outpath[FS_MAX_PATH-1] = '\0';
 
   return 0;
 }
@@ -1038,7 +1039,7 @@ fsdev_chdir(struct _reent *r,
   if(R_SUCCEEDED(rc))
   {
     fsDirClose(&fd);
-    strncpy(__cwd, __fixedpath, PATH_MAX);
+    strcpy(__cwd, __fixedpath);
     fsdev_fsdevice_cwd = device->id;
     return 0;
   }

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -199,7 +199,7 @@ fsdev_fixpath(struct _reent *r,
     strncpy(__fixedpath, path, PATH_MAX);
   else
   {
-    strcpy(__fixedpath, __cwd);
+    strncpy(__fixedpath, __cwd, PATH_MAX); __fixedpath[PATH_MAX] = 0;
     strncat(__fixedpath, path, PATH_MAX - strlen(__cwd));
   }
 
@@ -1039,7 +1039,7 @@ fsdev_chdir(struct _reent *r,
   if(R_SUCCEEDED(rc))
   {
     fsDirClose(&fd);
-    strcpy(__cwd, __fixedpath);
+    strncpy(__cwd, __fixedpath, PATH_MAX);__cwd[PATH_MAX] = 0;
     fsdev_fsdevice_cwd = device->id;
     return 0;
   }

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -241,7 +241,6 @@ fsdev_getfspath(struct _reent *r,
   if(fsdev_fixpath(r, path, device) == NULL)
     return -1;
 
-  memset(outpath, 0, FS_MAX_PATH);
   memcpy(outpath, __fixedpath,FS_MAX_PATH-1);
   outpath[FS_MAX_PATH-1] = '\0';
 

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -199,7 +199,8 @@ fsdev_fixpath(struct _reent *r,
     strncpy(__fixedpath, path, PATH_MAX);
   else
   {
-    strncpy(__fixedpath, __cwd, PATH_MAX); __fixedpath[PATH_MAX] = 0;
+    strncpy(__fixedpath, __cwd, PATH_MAX);
+    __fixedpath[PATH_MAX] = '\0';
     strncat(__fixedpath, path, PATH_MAX - strlen(__cwd));
   }
 
@@ -1038,7 +1039,8 @@ fsdev_chdir(struct _reent *r,
   if(R_SUCCEEDED(rc))
   {
     fsDirClose(&fd);
-    strncpy(__cwd, __fixedpath, PATH_MAX);__cwd[PATH_MAX] = 0;
+    strncpy(__cwd, __fixedpath, PATH_MAX);
+    __cwd[PATH_MAX] = '\0';
     fsdev_fsdevice_cwd = device->id;
     return 0;
   }

--- a/nx/source/services/fsldr.c
+++ b/nx/source/services/fsldr.c
@@ -36,7 +36,7 @@ void fsldrExit(void) {
 }
 
 Result fsldrOpenCodeFileSystem(u64 tid, const char *path, FsFileSystem* out) {
-    char send_path[FS_MAX_PATH] = {0};
+    char send_path[FS_MAX_PATH+1] = {0};
     IpcCommand c;
     ipcInitialize(&c);
     ipcAddSendStatic(&c, send_path, FS_MAX_PATH, 0);

--- a/nx/source/services/lr.c
+++ b/nx/source/services/lr.c
@@ -144,7 +144,7 @@ static Result _lrResolvePath(Service* s, u64 cmd_id, u64 tid, char *out) {
     This is a helper function to perform the work for those funcs, given a command ID.
 */
 static Result _lrRedirectPath(Service* s, u64 cmd_id, u64 tid, const char *path) {
-    char send_path[FS_MAX_PATH] = {0};
+    char send_path[FS_MAX_PATH+1] = {0};
     IpcCommand c;
     ipcInitialize(&c);
     ipcAddSendStatic(&c, send_path, FS_MAX_PATH, 0);


### PR DESCRIPTION
avoid gcc 8.1.0 diagnostics as per https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Warning-Options.html#index-Wstringop-truncation