### PR TITLE
Add string.h to remove compile error

### DIFF
--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -6,7 +6,6 @@
  * @copyright libnx Authors
  */
 #include <string.h>
-
 #include "types.h"
 #include "result.h"
 #include "arm/atomics.h"

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -5,7 +5,6 @@
  * @author yellows8
  * @copyright libnx Authors
  */
-
 #include <string.h>
 #include "types.h"
 #include "result.h"

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -5,6 +5,7 @@
  * @author yellows8
  * @copyright libnx Authors
  */
+
 #include <string.h>
 #include "types.h"
 #include "result.h"

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -5,6 +5,8 @@
  * @author yellows8
  * @copyright libnx Authors
  */
+#include <string.h>
+
 #include "types.h"
 #include "result.h"
 #include "arm/atomics.h"


### PR DESCRIPTION
memset and memcpy requires string.h