### PR TITLE
fix ioctl

### DIFF
--- a/nx/source/runtime/devices/socket.c
+++ b/nx/source/runtime/devices/socket.c
@@ -544,7 +544,7 @@ int ioctl(int fd, int request, ...) {
         return -1;
     }
 
-    fd = request != FIONBIO ? _socketGetFd(fd) : fd;
+    fd = request == FIONBIO ? _socketGetFd(fd) : fd;
     if(fd == -1)
         return -1;
 


### PR DESCRIPTION
fcntl needs newlib fd but Bsd calls need horizon fd. Ternary statement was reversed.