### PR TITLE
Fix mutexUnlock

### DIFF
--- a/nx/source/kernel/mutex.c
+++ b/nx/source/kernel/mutex.c
@@ -35,7 +35,7 @@ void mutexLock(Mutex* m) {
 
             if (old == cur) {
                 // Flag was set successfully.
-                svcArbitrateLock(cur &~ HAS_LISTENERS, (u32*)m, self);
+                svcArbitrateLock(cur, (u32*)m, self);
             }
         }
     }
@@ -59,7 +59,7 @@ bool mutexTryLock(Mutex* m) {
 }
 
 void mutexUnlock(Mutex* m) {
-    u32 old = __sync_lock_test_and_set((u32*)m, 0);
+    u32 old = __sync_val_compare_and_swap((u32*)m, _GetTag(), 0);
 
     if (old & HAS_LISTENERS) {
         svcArbitrateUnlock((u32*)m);


### PR DESCRIPTION
Currently, mutex unlock will try to exchange the current mutex value with 0, and, if the has listeners flag is set, it calls the ArbitrateUnlock svc. However, between the time that the mutex value is set to 0 and ArbitrateUnlock runs, its possible that mutexLock is called before ArbitrateUnlock writes the new thread handle. Basically, this scenario is possible currently:

(Consider that Thread A, B and C are all running at different cores).

- Thread A tries to acquire the mutex, and succeeds as no thread is holding it yet.
- Thread C tries to acquire the mutex, but fails and waits (calling svcAbitrateLock) because thread A is already holding it.
- Thread A calls mutexUnlock, sync_lock_test_and_set writes 0 at mutex address.
- Thread B calls mutexLock, since the value at the mutex address is 0 it is able to acquire the mutex successfully (it thinks that no thread is holding the mutex).
- Still on thread A, mutexUnlock then calls svcArbitrateUnlock as the old value indicates that a thread (in particular, Thread B) was waiting for the mutex (has listeners flag is set). svcArbitrateUnlock then pops Thread B from the queue of threads waiting for the mutex, and gives the mutex to Thread B, also updating the value at mutex address to indicate that Thread B is holding it.

On this scenario, both Thread B and Thread C were able to acquire the mutex, which could lead to race conditions later on.

The proposed fix is ensuring that no thread is waiting for the mutex before writing zero. This is done by atomically comparing if the value at mutex address is equal to the current thread handle, and only if so, then write 0. Oherwise the svc needs to be called. In this case, the scenario above wouldn't occur as this step:
- _Thread A calls mutexUnlock, sync_lock_test_and_set writes 0 at mutex address.
Wouldn't occur anymore as Thread C trying to acquire the mutex would set the has listeners flag and then the compare with the thread handle would fail, and the mutex value would then be kept untouched (the remaining work being done by svcArbitrateUnlock only).

Please note that I'm not able to test this fix currently, so it would be nice if someone could test it.