### PR TITLE
Fatal: Make fatalSimple not create report, add FatalType enum

### DIFF
--- a/nx/include/switch/services/fatal.h
+++ b/nx/include/switch/services/fatal.h
@@ -7,9 +7,23 @@
 #pragma once
 #include "../types.h"
 
+typedef enum {
+    FatalType_ErrorReportAndErrorScreen = 0,
+    FatalType_ErrorReport = 1,
+    FatalType_ErrorScreen = 2
+} FatalType;
+
 /**
  * @brief Triggers a system fatal error.
  * @param err[in] Result code to throw.
  * @note This function does not return.
  */
 void NORETURN fatalSimple(Result err);
+
+/**
+ * @brief Triggers a system fatal error with a custom FatalType.
+ * @param err[in] Result code to throw.
+ * @param err[in] Type of fatal error to throw.
+ * @note This function does not return.
+ */
+void NORETURN fatalWithType(Result err, FatalType type);

--- a/nx/source/services/fatal.c
+++ b/nx/source/services/fatal.c
@@ -7,7 +7,12 @@
 #include "services/fatal.h"
 #include "services/sm.h"
 
-void fatalSimple(Result err) {
+void NORETURN fatalSimple(Result err) {
+    /* By default, do not generate an error report. */
+    fatalWithType(err, FatalType_ErrorScreen);
+}
+
+void NORETURN fatalWithType(Result err, FatalType type) {
     Result rc = 0;
 
     if (detectDebugger()) {
@@ -31,7 +36,7 @@ void fatalSimple(Result err) {
                 u64 magic;
                 u64 cmd_id;
                 u64 result;
-                u64 unknown;
+                u64 type;
             } *raw;
 
             raw = ipcPrepareHeader(&c, sizeof(*raw));
@@ -39,7 +44,7 @@ void fatalSimple(Result err) {
             raw->magic = SFCI_MAGIC;
             raw->cmd_id = 1;
             raw->result = err;
-            raw->unknown = 0;
+            raw->type = type;
 
             ipcDispatch(srv);
         }


### PR DESCRIPTION
This adds a new "fatalWithType" function, and refactors fatalSimple to call it.

Also adds an appropriate enum for FatalType.