### PR TITLE
Re-introduce socklen_t definition to netdb.h

### DIFF
--- a/nx/external/bsd/include/netdb.h
+++ b/nx/external/bsd/include/netdb.h
@@ -68,6 +68,11 @@
 #include <sys/_types.h>
 #include <stdint.h>
 
+#ifndef _SOCKLEN_T_DECLARED
+typedef	__socklen_t	socklen_t;
+#define	_SOCKLEN_T_DECLARED
+#endif
+
 extern __thread int h_errno;
 // Removed some FreeBSD definitions
 


### PR DESCRIPTION
Fixes compilation error that complains about unknown type `socklen_t` when including `netdb.h` anywhere. 

The original FreeBSD `netdb.h` has this typedef: https://github.com/freebsd/freebsd/blob/master/include/netdb.h#L80

