### PR TITLE
Fix data race by reordering in detect.c's _CacheValues

### DIFF
--- a/nx/source/kernel/detect.c
+++ b/nx/source/kernel/detect.c
@@ -13,7 +13,7 @@ static Mutex g_Mutex;
 
 static void _CacheValues(void)
 {
-    if (g_HasCached)
+    if (__atomic_load_n(&g_HasCached, __ATOMIC_SEQ_CST))
         return;
 
     mutexLock(&g_Mutex);
@@ -33,7 +33,7 @@ static void _CacheValues(void)
     g_IsAbove300 |= g_IsAbove400;
     g_IsAbove200 |= g_IsAbove300;
 
-    g_HasCached = true;
+    __atomic_store_n(&g_HasCached, true, __ATOMIC_SEQ_CST);
 
     mutexUnlock(&g_Mutex);
 }


### PR DESCRIPTION
Compilers have that annoying property to reorder store ops. This introduces a data race in detect.c's _CacheValues. The following disassembler output shows that in this instance, the compiled code writes to g_HasCached before writing to g_IsAbove400:

```
.text._CacheValues:00000000000000D8  MOV   X1, #0x14
.text._CacheValues:00000000000000DC  BL    svcGetInfo
.text._CacheValues:00000000000000E0  LDRB  W2, [X25,#g_IsAbove400@PAGEOFF]
.text._CacheValues:00000000000000E4  ADRP  X3, #g_IsAbove500@PAGE
.text._CacheValues:00000000000000E8  CMP   W0, W22
.text._CacheValues:00000000000000EC  CSET  W4, NE
.text._CacheValues:00000000000000F0  MOV   W5, #1
.text._CacheValues:00000000000000F4  MOV   X0, X20
.text._CacheValues:00000000000000F8  LDRB  W1, [X24,#g_IsAbove300@PAGEOFF]
.text._CacheValues:00000000000000FC  STRB  W4, [X3,#g_IsAbove500@PAGEOFF]
.text._CacheValues:0000000000000100  LDRB  W3, [X23,#g_IsAbove200@PAGEOFF]
.text._CacheValues:0000000000000104  ORR   W2, W2, W4
.text._CacheValues:0000000000000108  STRB  W5, [X19,#g_HasCached@PAGEOFF]
.text._CacheValues:000000000000010C  ORR   W1, W1, W2
.text._CacheValues:0000000000000110  STRB  W2, [X25,#g_IsAbove400@PAGEOFF]
.text._CacheValues:0000000000000114  ORR   W2, W1, W3
.text._CacheValues:0000000000000118  STRB  W1, [X24,#g_IsAbove300@PAGEOFF]
.text._CacheValues:000000000000011C  STRB  W2, [X23,#g_IsAbove200@PAGEOFF]
.text._CacheValues:0000000000000120  BL    mutexUnlock
```

This patch fixes the issue by using GCC atomic primitives for enforcing proper ordering. Additionally memory access in ARMv8 is weakly-ordered and thus special read/write ops must be used for global variables such as g_HasCached (unless explicit synchronization with a mutex was done before, yada yada.) This is addressed by GCC's atomic primitives too.

Note: This bug probably never surfaced in practice, because an application is likely to call into some function of detect.c before launching threads. I just noticed it while reading through the code.