### PR TITLE
Added `nifmGetInternetConnectionStatus`.

### DIFF
--- a/nx/include/switch/services/nifm.h
+++ b/nx/include/switch/services/nifm.h
@@ -12,7 +12,18 @@
 
 #include "../services/sm.h"
 
+/// nifm internet connection status.
+typedef struct NifmInternetConnectionStatus NifmInternetConnectionStatus;
+
+struct NifmInternetConnectionStatus
+{
+    bool wirelessCommunicationEnabled;
+    bool ethernetCommunicationEnabled;
+};
+
+
 Result nifmInitialize(void);
 void nifmExit(void);
 
 Result nifmGetCurrentIpAddress(u32* out);
+Result nifmGetInternetConnectionStatus(NifmInternetConnectionStatus* out);

--- a/nx/source/services/nifm.c
+++ b/nx/source/services/nifm.c
@@ -77,6 +77,40 @@ Result nifmGetCurrentIpAddress(u32* out) {
     return rc;
 }
 
+Result nifmGetInternetConnectionStatus(NifmInternetConnectionStatus* out) {
+    IpcCommand c;
+    ipcInitialize(&c);
+
+    struct {
+        u64 magic;
+        u64 cmd_id;
+    } * raw;
+
+    raw = ipcPrepareHeader(&c, sizeof(*raw));
+
+    raw->magic = SFCI_MAGIC;
+    raw->cmd_id = 18;
+
+    Result rc = serviceIpcDispatch(&g_nifmIGS);
+
+    if (R_SUCCEEDED(rc)) {
+        IpcParsedCommand r;
+        ipcParse(&r);
+
+        struct {
+            u64 magic;
+            u64 result;
+            u32 out;
+        }* resp = r.Raw;
+
+        rc = resp->result;
+        out->wirelessCommunicationEnabled = resp->out & 1;
+        out->ethernetCommunicationEnabled = (resp->out >> 1) & 1;
+    }
+
+    return rc;
+}
+
 static Result _nifmCreateGeneralService(Service* out, u64 in) {
     IpcCommand c;
     ipcInitialize(&c);


### PR DESCRIPTION
Also tried to add `nifmIsWirelessCommunicationEnabled`, and `nifmIsEthernetCommunicationEnabled`. However at least on my 4.1.0 Switch they don't seem to work correctly. `nifmIsWirelessCommunicationEnabled` (cmd: 17) will return true whenever there is any network connection and `nifmIsEthernetCommunicationEnabled` (cmd: 20) always returns false.