### PR TITLE
hid: Correct bitwise AND for pro controllers in hidInitializeVibrationDevices()

### DIFF
--- a/nx/source/services/hid.c
+++ b/nx/source/services/hid.c
@@ -932,7 +932,7 @@ Result hidInitializeVibrationDevices(u32 *VibrationDeviceHandles, size_t total_h
     if (tmp_id == CONTROLLER_HANDHELD)
         tmp_id = 0x20;
 
-    if (tmp_type & LAYOUT_PROCONTROLLER) {
+    if (tmp_type & TYPE_PROCONTROLLER) {
         tmp_type = 3;
     }
     else if (tmp_type & TYPE_HANDHELD) {


### PR DESCRIPTION
`LAYOUT_PROCONTROLLER` is a value of zero, so the bitwise AND condition here would always be false (`TYPE_PROCONTROLLER`, on the other hand is a value of 1)