### PR TITLE
added barrier synchronization primitive and linked list

### DIFF
--- a/nx/include/switch.h
+++ b/nx/include/switch.h
@@ -28,6 +28,7 @@ extern "C" {
 #include "switch/kernel/condvar.h"
 #include "switch/kernel/thread.h"
 #include "switch/kernel/semaphore.h"
+#include "switch/kernel/barrier.h"
 #include "switch/kernel/virtmem.h"
 #include "switch/kernel/detect.h"
 #include "switch/kernel/random.h"
@@ -75,6 +76,7 @@ extern "C" {
 #include "switch/runtime/nxlink.h"
 
 #include "switch/runtime/util/utf.h"
+#include "switch/runtime/util/list.h"
 
 #include "switch/runtime/devices/console.h"
 #include "switch/runtime/devices/usb_comms.h"

--- a/nx/include/switch/kernel/barrier.h
+++ b/nx/include/switch/kernel/barrier.h
@@ -5,9 +5,9 @@
  * @copyright libnx Authors
  */
 #pragma once
-#include "../types.h"
 #include "condvar.h"
 #include "mutex.h"
+#include "thread.h"
 #include "../runtime/util/list.h"
 
 typedef struct barrier {

--- a/nx/include/switch/kernel/barrier.h
+++ b/nx/include/switch/kernel/barrier.h
@@ -1,0 +1,24 @@
+/**
+ * @file barrier.h
+ * @brief Barrier synchronization primitive.
+ * @author Yordrar
+ * @copyright libnx Authors
+ */
+#pragma once
+#include "../types.h"
+#include "condvar.h"
+#include "mutex.h"
+#include "../runtime/util/list.h"
+
+typedef struct barrier {
+    List threads_registered;
+    List threads_waiting;
+    RwLock mutex;
+    bool isInited;
+} Barrier;
+
+void barrierInit(Barrier* b);
+void barrierFree(Barrier* b);
+void barrierRegister(Barrier* b, Thread* thread);
+void barrierUnregister(Barrier* b, Thread* thread);
+void barrierWait(Barrier* b, Thread* thread);

--- a/nx/include/switch/kernel/barrier.h
+++ b/nx/include/switch/kernel/barrier.h
@@ -43,7 +43,7 @@ void barrierRegister(Barrier* b, Thread* thread);
 void barrierUnregister(Barrier* b, Thread* thread);
 
 /**
- * @brief Waits until all processes registered in the barrier call this function
+ * @brief Waits until all processes registered in the barrier call this function, if a not registered thread calls this function, it returns without waiting
  * @param b Barrier object
  */
 void barrierWait(Barrier* b);

--- a/nx/include/switch/kernel/barrier.h
+++ b/nx/include/switch/kernel/barrier.h
@@ -13,7 +13,7 @@
 typedef struct barrier {
     List threads_registered;
     List threads_waiting;
-    RwLock mutex;
+    Mutex mutex;
     bool isInited;
 } Barrier;
 

--- a/nx/include/switch/kernel/barrier.h
+++ b/nx/include/switch/kernel/barrier.h
@@ -14,11 +14,36 @@ typedef struct barrier {
     List threads_registered;
     List threads_waiting;
     Mutex mutex;
-    bool isInited;
 } Barrier;
 
+/**
+ * @brief Allocates memory for a barrier
+ * @param b Barrier object
+ */
 void barrierInit(Barrier* b);
+
+/**
+ * @brief Frees the memory allocated for a barrier
+ * @param b Barrier object
+ */
 void barrierFree(Barrier* b);
+
+/**
+ * @brief Registers a thread that is going to use the specified barrier
+ * @param b Barrier object
+ * @param thread The thread to register
+ */
 void barrierRegister(Barrier* b, Thread* thread);
+
+/**
+ * @brief Unegisters a thread that is not going to use anymore the specified barrier
+ * @param b Barrier object
+ * @param thread The thread to unregister
+ */
 void barrierUnregister(Barrier* b, Thread* thread);
-void barrierWait(Barrier* b, Thread* thread);
+
+/**
+ * @brief Waits until all processes registered in the barrier call this function
+ * @param b Barrier object
+ */
+void barrierWait(Barrier* b);

--- a/nx/include/switch/runtime/util/list.h
+++ b/nx/include/switch/runtime/util/list.h
@@ -1,0 +1,35 @@
+/**
+ * @file list.h
+ * @brief Singly Linked List data structure.
+ * @author Yordrar
+ * @copyright libnx Authors
+ */
+#pragma once
+#include "../types.h"
+#include "../kernel/condvar.h"
+#include "../kernel/mutex.h"
+
+typedef struct node {
+    void* item;
+    Node* next;
+} Node;
+
+typedef struct list {
+    Node* header;
+    Node* last;
+    u32 num_nodes;
+    RwLock mutex;
+    bool isInited;
+} List;
+
+void listInit(List* l);
+void listFree(List* l);
+void listInsert(List* l, void* item, u32 pos);
+static inline void listInsertFirst(List* l, void* item) {
+    listInsert(l, item, 0);
+}
+void listInsertLast(List* l, void* item);
+void listDelete(List* l, void* item);
+bool listIsInserted(List* l, void* item);
+u32 listGetNumNodes(List* l);
+void* listGetItem(List* l, u32 pos);

--- a/nx/include/switch/runtime/util/list.h
+++ b/nx/include/switch/runtime/util/list.h
@@ -5,13 +5,14 @@
  * @copyright libnx Authors
  */
 #pragma once
-#include "../types.h"
-#include "../kernel/condvar.h"
-#include "../kernel/mutex.h"
+#include "../../types.h"
+#include "../../kernel/condvar.h"
+#include "../../kernel/rwlock.h"
+#include "../../kernel/thread.h"
 
 typedef struct node {
     void* item;
-    Node* next;
+    struct node* next;
 } Node;
 
 typedef struct list {

--- a/nx/include/switch/runtime/util/list.h
+++ b/nx/include/switch/runtime/util/list.h
@@ -20,17 +20,70 @@ typedef struct list {
     Node* last;
     u32 num_nodes;
     RwLock mutex;
-    bool isInited;
 } List;
 
+/**
+ * @brief Allocates memory for a list
+ * @param l List object
+ */
 void listInit(List* l);
+
+/**
+ * @brief Frees memory allocated for a list
+ * @param l List object
+ */
 void listFree(List* l);
+
+/**
+ * @brief Inserts something in a position
+ * @param l List object.
+ * @param item A pointer to the thing you want to insert
+ * @param pos The position to insert (0 is the first position)
+ */
 void listInsert(List* l, void* item, u32 pos);
+
+/**
+ * @brief Inserts something in the first position
+ * @param l List object.
+ * @param item A pointer to the thing you want to insert
+ */
 static inline void listInsertFirst(List* l, void* item) {
     listInsert(l, item, 0);
 }
+
+/**
+ * @brief Inserts something at the end of the list
+ * @param l List object.
+ * @param item A pointer to the thing you want to insert
+ */
 void listInsertLast(List* l, void* item);
+
+/**
+ * @brief Deletes the node of the list which has the item specified (makes a pointer comparison to ckeck that)
+ * @param l List object.
+ * @param item A pointer to the thing you want to delete
+ */
 void listDelete(List* l, void* item);
+
+/**
+ * @brief Checks if the item is inserted in the list (makes a pointer comparison to ckeck that)
+ * @param l List object.
+ * @param item A pointer to the thing you want to check
+ * @return true if the item is in the list, false otherwise
+ */
 bool listIsInserted(List* l, void* item);
+
+/**
+ * @brief Returns the number of items inserted in the list
+ * @param l List object.
+ * @return The number of nodes (the number of inserted things) in the list
+ */
 u32 listGetNumNodes(List* l);
+
+/**
+ * @brief Returns the item inserted in an specified position
+ * @param l List object.
+ * @param pos The position of the item
+ * @return A pointer to that item, NULL if it isn't found
+ */
 void* listGetItem(List* l, u32 pos);

--- a/nx/include/switch/runtime/util/list.h
+++ b/nx/include/switch/runtime/util/list.h
@@ -117,7 +117,7 @@ void* listPeekFront(List* l);
  * @param item A pointer to something you want to insert
  */
 static inline void listPushBack(List* l, void* item) {
-    listInsertLast(List* l, void* item);
+    listInsertLast(l, item);
 }
 
 /**

--- a/nx/include/switch/runtime/util/list.h
+++ b/nx/include/switch/runtime/util/list.h
@@ -36,7 +36,7 @@ void listFree(List* l);
 
 /**
  * @brief Inserts something in a position
- * @param l List object.
+ * @param l List object
  * @param item A pointer to the thing you want to insert
  * @param pos The position to insert (0 is the first position)
  */
@@ -44,7 +44,7 @@ void listInsert(List* l, void* item, u32 pos);
 
 /**
  * @brief Inserts something in the first position
- * @param l List object.
+ * @param l List object
  * @param item A pointer to the thing you want to insert
  */
 static inline void listInsertFirst(List* l, void* item) {
@@ -53,21 +53,21 @@ static inline void listInsertFirst(List* l, void* item) {
 
 /**
  * @brief Inserts something at the end of the list
- * @param l List object.
+ * @param l List object
  * @param item A pointer to the thing you want to insert
  */
 void listInsertLast(List* l, void* item);
 
 /**
  * @brief Deletes the node of the list which has the item specified (makes a pointer comparison to ckeck that)
- * @param l List object.
+ * @param l List object
  * @param item A pointer to the thing you want to delete
  */
 void listDelete(List* l, void* item);
 
 /**
  * @brief Checks if the item is inserted in the list (makes a pointer comparison to ckeck that)
- * @param l List object.
+ * @param l List object
  * @param item A pointer to the thing you want to check
  * @return true if the item is in the list, false otherwise
  */
@@ -75,15 +75,61 @@ bool listIsInserted(List* l, void* item);
 
 /**
  * @brief Returns the number of items inserted in the list
- * @param l List object.
+ * @param l List object
  * @return The number of nodes (the number of inserted things) in the list
  */
 u32 listGetNumNodes(List* l);
 
 /**
  * @brief Returns the item inserted in an specified position
- * @param l List object.
+ * @param l List object
  * @param pos The position of the item
  * @return A pointer to that item, NULL if it isn't found
  */
 void* listGetItem(List* l, u32 pos);
+
+/**
+ * @brief Inserts the item in the first position
+ * @param l List object
+ * @param item A pointer to something to store
+ */
+static inline void listPushFront(List* l, void* item) {
+    listInsert(l, item, 0);
+}
+
+/**
+ * @brief Returns the item inserted in the first position and deletes it
+ * @param l List object
+ * @return A pointer to that item, NULL if the list is empty
+ */
+void* listPopFront(List* l);
+
+/**
+ * @brief Returns the item inserted in the first position
+ * @param l List object.
+ * @return A pointer to that item, NULL if the list is empty
+ */
+void* listPeekFront(List* l);
+
+/**
+ * @brief Inserts the item in the last position
+ * @param l List object.
+ * @param item A pointer to something you want to insert
+ */
+static inline void listPushBack(List* l, void* item) {
+    listInsertLast(List* l, void* item);
+}
+
+/**
+ * @brief Returns the item inserted in the last position and deletes it
+ * @param l List object.
+ * @return A pointer to that item, NULL if the list is empty
+ */
+void* listPopBack(List* l);
+
+/**
+ * @brief Returns the item inserted in the last position
+ * @param l List object.
+ * @return A pointer to that item, NULL if the list is empty
+ */
+void* listPeekBack(List* l);

--- a/nx/source/kernel/barrier.c
+++ b/nx/source/kernel/barrier.c
@@ -1,17 +1,27 @@
 #include "kernel/barrier.h"
 
 void barrierInit(Barrier* b) {
-    rwlockWriteLock(b->mutex);
+    mutexInit(&b->mutex);
+    mutexLock(&b->mutex);
     if(b->isInited) {
         return;
     }
     listInit(b->threads_registered);
     listInit(b->threads_waiting);
     b->isInited = true;
-    rwlockWriteUnlock(b->mutex);
+    mutexUnlock(&b->mutex);
 }
 
-void barrierFree(Barrier* b);
+void barrierFree(Barrier* b) {
+    mutexLock(&b->mutex);
+    if(!b->isInited) {
+        return;
+    }
+    listFree(b->threads_registered);
+    listFree(b->threads_waiting);
+    b->isInited = false;
+    mutexUnlock(&b->mutex);
+}
 
 void barrierRegister(Barrier* b, Thread* thread) {
     if(listIsInserted(b->threads_registered, (void*)thread)) {
@@ -28,12 +38,19 @@ void barrierWait(Barrier* b, Thread* thread) {
     if(!listIsInserted(b->threads_registered)) {
         return;
     }
-    threadPause((void*)thread);
-    listInsertLast(b->threads_waiting, thread);
 
-    if(listGetNumNodes(b->threads_registered) == listGetNumNodes(b->threads_waiting)) {
+    mutexLock(&b->mutex);
+    if(listGetNumNodes(b->threads_registered) == listGetNumNodes(b->threads_waiting)+1) {
         while(listGetNumNodes(b->threads_waiting) > 0) {
-            threadResume(listGetItem(b->threads_waiting, 0));
+            Thread* current_thread = listGetItem(b->threads_waiting, 0);
+            threadResume(current_thread);
+            listDelete(b->threads_waiting, current_thread);
         }
+        mutexUnlock(&b->mutex);
+    }
+    else {
+        listInsertLast(b->threads_waiting, thread);
+        mutexUnlock(&b->mutex);
+        threadPause((void*)thread);
     }
 }

--- a/nx/source/kernel/barrier.c
+++ b/nx/source/kernel/barrier.c
@@ -1,4 +1,5 @@
 #include "kernel/barrier.h"
+#include "../internal.h"
 
 void barrierInit(Barrier* b) {
     mutexInit(&b->mutex);
@@ -26,7 +27,7 @@ void barrierUnregister(Barrier* b, Thread* thread) {
     listDelete(&b->threads_registered, (void*)thread);
 }
 
-void barrierWait(Barrier* b, Thread* thread) {
+void barrierWait(Barrier* b) {
     Thread* thread = getThreadVars()->thread_ptr;
     if(!listIsInserted(&b->threads_registered, (void*)thread)) {
         return;

--- a/nx/source/kernel/barrier.c
+++ b/nx/source/kernel/barrier.c
@@ -1,0 +1,39 @@
+#include "kernel/barrier.h"
+
+void barrierInit(Barrier* b) {
+    rwlockWriteLock(b->mutex);
+    if(b->isInited) {
+        return;
+    }
+    listInit(b->threads_registered);
+    listInit(b->threads_waiting);
+    b->isInited = true;
+    rwlockWriteUnlock(b->mutex);
+}
+
+void barrierFree(Barrier* b);
+
+void barrierRegister(Barrier* b, Thread* thread) {
+    if(listIsInserted(b->threads_registered, (void*)thread)) {
+        return;
+    }
+    listInsertLast(b->threads_registered, (void*)thread);
+}
+
+void barrierUnregister(Barrier* b, Thread* thread) {
+    listDelete(b->threads_registered, (void*)thread);
+}
+
+void barrierWait(Barrier* b, Thread* thread) {
+    if(!listIsInserted(b->threads_registered)) {
+        return;
+    }
+    threadPause((void*)thread);
+    listInsertLast(b->threads_waiting, thread);
+
+    if(listGetNumNodes(b->threads_registered) == listGetNumNodes(b->threads_waiting)) {
+        while(listGetNumNodes(b->threads_waiting) > 0) {
+            threadResume(listGetItem(b->threads_waiting, 0));
+        }
+    }
+}

--- a/nx/source/runtime/util/list.c
+++ b/nx/source/runtime/util/list.c
@@ -1,0 +1,136 @@
+#include "runtime/util/list.h"
+#include <stdlib.h>
+
+void listInit(List* l) {
+    rwlockWriteLock(l->mutex);
+    if(l->isInited) {
+        return;
+    }
+    Node* header = (Node*)malloc(sizeof(Node));
+    header->item = NULL;
+    header->next = NULL;
+
+    l->header = header;
+    l->last = header;
+    l->num_nodes = 0;
+    l->isInited = true;
+    rwlockWriteUnlock(l->mutex);
+}
+
+void listFree(List* l) {
+    rwlockWriteLock(l->mutex);
+    if(!l->isInited) {
+        return;
+    }
+    Node* aux = l->header;
+    while(aux != NULL) {
+        free(aux);
+        aux = aux->next;
+    }
+    l->header = NULL;
+    l->last = NULL;
+    l->num_nodes = 0;
+    l->isInited = false;
+    rwlockWriteUnlock(l->mutex);
+}
+
+void listInsert(List* l, void* item, u32 pos) {
+    rwlockReadLock(l->mutex);
+    if(!l->isInited) {
+        return;
+    }
+    if(pos > l->num_nodes || pos < 0) {
+        return;
+    }
+    rwlockReadUnlock(l->mutex);
+
+    rwlockWriteLock(l->mutex);
+    Node* aux = l->header;
+    for(u32 i = pos; i > 0; i--) {
+        aux = aux->next;
+    }
+
+    Node* new = (Node*)malloc(sizeof(Node));
+    new->item = item;
+    new->next = aux->next;
+    aux->next = new;
+
+    l->num_nodes++;
+    rwlockWriteUnlock(l->mutex);
+}
+
+void listInsertLast(List* l, void* item) {
+    rwlockWriteLock(l->mutex);
+    if(!l->isInited) {
+        return;
+    }
+    Node* new = (Node*)malloc(sizeof(Node));
+    new->item = item;
+    new->next = NULL;
+    
+    l->last->next = new;
+    l->last = new;
+    rwlockWriteUnlock(l->mutex);
+}
+
+void listDelete(List* l, void* item) {
+    rwlockWriteLock(l->mutex);
+    if(!l->isInited) {
+        return;
+    }
+
+    Node* aux = l->header;
+    while(aux->next != NULL && aux->next->item != item) {
+        aux = aux->next;
+    }
+
+    if(aux->next != NULL && aux->next->item == item) {
+        Node* delete = aux->next;
+        aux->next = delete->next;
+        free(delete);
+        l->num_nodes--;
+    } 
+
+    rwlockWriteUnlock(l->mutex);
+}
+
+bool listIsInserted(List* l, void* item) {
+    rwlockReadLock(l->mutex);
+    if(!l->isInited) {
+        return;
+    }
+    Node* aux = l->header;
+    while(aux != NULL && aux->item != item) {
+        aux = aux->next;
+    }
+    bool result = aux == NULL ? false : true;
+    rwlockReadUnlock(l->mutex);
+    return result;
+}
+
+u32 listGetNumNodes(List* l) {
+    rwlockReadLock(l->mutex);
+    if(!l->isInited) {
+        return;
+    }
+    u32 result = l->num_nodes;
+    rwlockReadUnlock(l->mutex);
+    return result;
+}
+
+void* listGetItem(List* l, u32 pos) {
+    rwlockReadLock(l->mutex);
+    if(!l->isInited) {
+        return;
+    }
+    if(pos >= l->num_nodes || pos < 0) {
+        return;
+    }
+    Node* aux = l->header->next;
+    for(u32 i = pos; i > 0; i--) {
+        aux = aux->next;
+    }
+    void* result = aux->item;
+    rwlockReadUnlock(l->mutex);
+    return result;
+}

--- a/nx/source/runtime/util/list.c
+++ b/nx/source/runtime/util/list.c
@@ -81,6 +81,22 @@ void listDelete(List* l, void* item) {
     rwlockWriteUnlock(&l->mutex);
 }
 
+void listDeleteAtPos(List* l, u32 pos) {
+    rwlockReadLock(&l->mutex);
+    if(pos >= l->num_nodes || pos < 0) {
+        return;
+    }
+    Node* aux = l->header;
+    for(int i = pos; i > 0; i++) {
+        aux = aux->next;
+    }
+    Node* delete = aux->next;
+    aux->next = delete->next;
+    free(delete);
+    l->num_nodes--;
+    rwlockReadUnlock(&l->mutex);
+}
+
 bool listIsInserted(List* l, void* item) {
     rwlockReadLock(&l->mutex);
     Node* aux = l->header;
@@ -109,6 +125,48 @@ void* listGetItem(List* l, u32 pos) {
         aux = aux->next;
     }
     void* result = aux->item;
+    rwlockReadUnlock(&l->mutex);
+    return result;
+}
+
+void* listPopFront(List* l) {
+    rwlockReadLock(&l->mutex);
+    if(l->num_nodes == 0) {
+        return NULL;
+    }
+    void* result = listGetItem(l, 0);
+    listDeleteAtPos(l, 0);
+    rwlockReadUnlock(&l->mutex);
+    return result;
+}
+
+void* listPeekFront(List* l) {
+    rwlockReadLock(&l->mutex);
+    if(l->num_nodes == 0) {
+        return NULL;
+    }
+    void* result = listGetItem(l, 0);
+    rwlockReadUnlock(&l->mutex);
+    return result;
+}
+
+void* listPopBack(List* l) {
+    rwlockReadLock(&l->mutex);
+    if(l->num_nodes == 0) {
+        return NULL;
+    }
+    void* result = listGetItem(l, l->num_nodes-1);
+    listDeleteAtPos(l, l->num_nodes-1);
+    rwlockReadUnlock(&l->mutex);
+    return result;
+}
+
+void* listPeekBack(List* l) {
+    rwlockReadLock(&l->mutex);
+    if(l->num_nodes == 0) {
+        return NULL;
+    }
+    void* result = listGetItem(l, l->num_nodes-1);
     rwlockReadUnlock(&l->mutex);
     return result;
 }

--- a/nx/source/runtime/util/list.c
+++ b/nx/source/runtime/util/list.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 
 void listInit(List* l) {
-    rwlockWriteLock(l->mutex);
+    rwlockWriteLock(&l->mutex);
     if(l->isInited) {
         return;
     }
@@ -14,11 +14,11 @@ void listInit(List* l) {
     l->last = header;
     l->num_nodes = 0;
     l->isInited = true;
-    rwlockWriteUnlock(l->mutex);
+    rwlockWriteUnlock(&l->mutex);
 }
 
 void listFree(List* l) {
-    rwlockWriteLock(l->mutex);
+    rwlockWriteLock(&l->mutex);
     if(!l->isInited) {
         return;
     }
@@ -31,20 +31,20 @@ void listFree(List* l) {
     l->last = NULL;
     l->num_nodes = 0;
     l->isInited = false;
-    rwlockWriteUnlock(l->mutex);
+    rwlockWriteUnlock(&l->mutex);
 }
 
 void listInsert(List* l, void* item, u32 pos) {
-    rwlockReadLock(l->mutex);
+    rwlockReadLock(&l->mutex);
     if(!l->isInited) {
         return;
     }
     if(pos > l->num_nodes || pos < 0) {
         return;
     }
-    rwlockReadUnlock(l->mutex);
+    rwlockReadUnlock(&l->mutex);
 
-    rwlockWriteLock(l->mutex);
+    rwlockWriteLock(&l->mutex);
     Node* aux = l->header;
     for(u32 i = pos; i > 0; i--) {
         aux = aux->next;
@@ -56,11 +56,11 @@ void listInsert(List* l, void* item, u32 pos) {
     aux->next = new;
 
     l->num_nodes++;
-    rwlockWriteUnlock(l->mutex);
+    rwlockWriteUnlock(&l->mutex);
 }
 
 void listInsertLast(List* l, void* item) {
-    rwlockWriteLock(l->mutex);
+    rwlockWriteLock(&l->mutex);
     if(!l->isInited) {
         return;
     }
@@ -70,11 +70,11 @@ void listInsertLast(List* l, void* item) {
     
     l->last->next = new;
     l->last = new;
-    rwlockWriteUnlock(l->mutex);
+    rwlockWriteUnlock(&l->mutex);
 }
 
 void listDelete(List* l, void* item) {
-    rwlockWriteLock(l->mutex);
+    rwlockWriteLock(&l->mutex);
     if(!l->isInited) {
         return;
     }
@@ -91,11 +91,11 @@ void listDelete(List* l, void* item) {
         l->num_nodes--;
     } 
 
-    rwlockWriteUnlock(l->mutex);
+    rwlockWriteUnlock(&l->mutex);
 }
 
 bool listIsInserted(List* l, void* item) {
-    rwlockReadLock(l->mutex);
+    rwlockReadLock(&l->mutex);
     if(!l->isInited) {
         return;
     }
@@ -104,22 +104,22 @@ bool listIsInserted(List* l, void* item) {
         aux = aux->next;
     }
     bool result = aux == NULL ? false : true;
-    rwlockReadUnlock(l->mutex);
+    rwlockReadUnlock(&l->mutex);
     return result;
 }
 
 u32 listGetNumNodes(List* l) {
-    rwlockReadLock(l->mutex);
+    rwlockReadLock(&l->mutex);
     if(!l->isInited) {
         return;
     }
     u32 result = l->num_nodes;
-    rwlockReadUnlock(l->mutex);
+    rwlockReadUnlock(&l->mutex);
     return result;
 }
 
 void* listGetItem(List* l, u32 pos) {
-    rwlockReadLock(l->mutex);
+    rwlockReadLock(&l->mutex);
     if(!l->isInited) {
         return;
     }
@@ -131,6 +131,6 @@ void* listGetItem(List* l, u32 pos) {
         aux = aux->next;
     }
     void* result = aux->item;
-    rwlockReadUnlock(l->mutex);
+    rwlockReadUnlock(&l->mutex);
     return result;
 }


### PR DESCRIPTION
Not a very used sync primitive but I thought it could be a nice to have.
Also, as the barrier uses two lists, I had to implement it, it is thread-safe, stores void* so it can store whatever you want and has some quality of life functions that allow an easy use as if it were a stack or queue (push/pop/peek) and is somewhat useful for those coding in plain C.
They are both tested and functioning in yuzu and firmware 5.1.0