### PR TITLE
Fixed nifm not initializing properly for > 1.0.0 < 3.0.0

### DIFF
--- a/nx/source/services/nifm.c
+++ b/nx/source/services/nifm.c
@@ -25,7 +25,7 @@ Result nifmInitialize(void) {
     rc = smGetService(&g_nifmSrv, "nifm:u");
 
     if (R_SUCCEEDED(rc)) {
-        if (kernelAbove200())
+        if (kernelAbove300())
             rc = _nifmCreateGeneralService(&g_nifmIGS, 0); // What does this parameter do?
         else
             rc = _nifmCreateGeneralServiceOld(&g_nifmIGS);


### PR DESCRIPTION
Untested, however, CreateGeneralServiceOld was not added until 3.0.0. This means 2.0.0->2.3.0 would try to call a non-existent cmd.