### PR TITLE
Resolve trivial -Wmissing-prototypes warnings

### DIFF
--- a/nx/include/switch/nvidia/ioctl.h
+++ b/nx/include/switch/nvidia/ioctl.h
@@ -155,6 +155,9 @@ typedef struct {
     u16 status; // always -1
 } NvError;
 
+Result nvioctlNvhostCtrl_SyncptRead(u32 fd, u32 id, u32* out);
+Result nvioctlNvhostCtrl_SyncptIncr(u32 fd, u32 id);
+Result nvioctlNvhostCtrl_SyncptWait(u32 fd, u32 id, u32 threshold, u32 timeout);
 Result nvioctlNvhostCtrl_EventSignal(u32 fd, u32 event_id);
 Result nvioctlNvhostCtrl_EventWait(u32 fd, u32 syncpt_id, u32 threshold, s32 timeout, u32 event_id, u32 *out);
 Result nvioctlNvhostCtrl_EventWaitAsync(u32 fd, u32 syncpt_id, u32 threshold, s32 timeout, u32 event_id);

--- a/nx/include/switch/services/fsldr.h
+++ b/nx/include/switch/services/fsldr.h
@@ -14,4 +14,4 @@ void fsldrExit(void);
 
 Result fsldrOpenCodeFileSystem(u64 tid, const char *path, FsFileSystem* out);
 Result fsldrIsArchivedProgram(u64 pid, bool *out);
-Result fsldrSetCurrentProcess();
+Result fsldrSetCurrentProcess(void);

--- a/nx/include/switch/services/ns.h
+++ b/nx/include/switch/services/ns.h
@@ -62,8 +62,8 @@ Result nsvmNeedsUpdateVulnerability(bool *out);
 Result nsvmGetSafeSystemVersion(u16 *out);
 
 /* ns:dev */
-Result nsdevInitialize();
-void nsdevExit();
+Result nsdevInitialize(void);
+void nsdevExit(void);
 
 Result nsdevTerminateProcess(u64 pid);
 Result nsdevTerminateProgram(u64 tid);

--- a/nx/source/services/csrng.c
+++ b/nx/source/services/csrng.c
@@ -5,6 +5,7 @@
 #include "arm/atomics.h"
 #include "kernel/ipc.h"
 #include "kernel/detect.h"
+#include "services/csrng.h"
 #include "services/sm.h"
 #include "services/spl.h"
 

--- a/nx/source/services/fsldr.c
+++ b/nx/source/services/fsldr.c
@@ -12,7 +12,7 @@
 static Service g_fsldrSrv;
 static u64 g_fsldrRefCnt;
 
-Result fsldrSetCurrentProcess();
+Result fsldrSetCurrentProcess(void);
 
 Result fsldrInitialize(void) {
     atomicIncrement64(&g_fsldrRefCnt);
@@ -111,7 +111,7 @@ Result fsldrIsArchivedProgram(u64 pid, bool *out) {
     return rc;
 }
 
-Result fsldrSetCurrentProcess() {
+Result fsldrSetCurrentProcess(void) {
     IpcCommand c;
     ipcInitialize(&c);
     ipcSendPid(&c);

--- a/nx/source/services/ns.c
+++ b/nx/source/services/ns.c
@@ -43,7 +43,7 @@ void nsExit(void)
     }
 }
 
-Result nsdevInitialize() {
+Result nsdevInitialize(void) {
     atomicIncrement64(&g_nsdevRefCnt);
     
     if (serviceIsActive(&g_nsdevSrv))
@@ -52,7 +52,7 @@ Result nsdevInitialize() {
     return smGetService(&g_nsdevSrv, "ns:dev");
 }
 
-void nsdevExit() {
+void nsdevExit(void) {
     if (atomicDecrement64(&g_nsdevRefCnt) == 0)
         serviceClose(&g_nsdevSrv);
 }


### PR DESCRIPTION
Gets rid of trivial warnings caused by headers not being included into the relevant .c file, empty parameter lists missing void, or functions missing a prototype in the header.

I've included the Nvidia ioctl prototypes that were missing, but can omit those if that interface is still in flux. 