### PR TITLE
Add psm:GetChargerType

### DIFF
--- a/nx/include/switch/services/psm.h
+++ b/nx/include/switch/services/psm.h
@@ -7,7 +7,14 @@
 #pragma once
 #include "../types.h"
 
+typedef enum {
+    ChargerType_None = 0,    ///< No charger
+    ChargerType_Charger = 1, ///< Official charger or dock
+    ChargerType_Usb = 2      ///< Other USB-C chargers
+} ChargerType;
+
 Result psmInitialize(void);
 void psmExit(void);
 
 Result psmGetBatteryChargePercentage(u32 *out);
+Result psmGetChargerType(ChargerType *out);

--- a/nx/source/services/psm.c
+++ b/nx/source/services/psm.c
@@ -65,3 +65,40 @@ Result psmGetBatteryChargePercentage(u32 *out)
     
     return rc;
 }
+
+Result psmGetChargerType(ChargerType *out)
+{
+    IpcCommand c;
+    ipcInitialize(&c);
+
+    struct {
+        u64 magic;
+        u64 cmd_id;
+    } *raw;
+
+    raw = ipcPrepareHeader(&c, sizeof(*raw));
+
+    raw->magic = SFCI_MAGIC;
+    raw->cmd_id = 1;
+
+    Result rc = serviceIpcDispatch(&g_psmSrv);
+
+    if(R_SUCCEEDED(rc)) {
+        IpcParsedCommand r;
+        ipcParse(&r);
+
+        struct {
+            u64 magic;
+            u64 result;
+            u32 charger;
+        } *resp = r.Raw;
+
+        rc = resp->result;
+
+        if (R_SUCCEEDED(rc)) {
+            *out = resp->charger;
+        }
+    }
+
+    return rc;
+}


### PR DESCRIPTION
Don't know if the names are correct but the only thing that returns ChargerType 1 is the official charging cable (be it directly or through the dock)--every other USB-C device I've plugged in returns 2.