### PR TITLE
kernel/random: Avoid casting away const in the U8TO32_LITTLE macro

### DIFF
--- a/nx/source/kernel/random.c
+++ b/nx/source/kernel/random.c
@@ -20,7 +20,7 @@
     (*(u32*)(p) = (v))
 
 #define U8TO32_LITTLE(p) \
-    (*(u32*)(p))
+    (*(const u32*)(p))
 
 #define ROTATE(v,c) (ROTL32(v,c))
 #define XOR(v,w) ((v) ^ (w))


### PR DESCRIPTION
This macro is only ever used with const input data within `chachaInit()` a little further down at line 68, which causes `-Wcast-qual` warnings. This is trivial enough to fix by preserving the qualifier within the cast.