### PR TITLE
applet: Add appletSelfExit()

### DIFF
--- a/nx/include/switch/services/applet.h
+++ b/nx/include/switch/services/applet.h
@@ -72,6 +72,12 @@ Result appletSetScreenShotPermission(s32 val);
 Result appletSetScreenShotImageOrientation(s32 val);
 
 /**
+ * @brief Exits the application.
+ * @note Can only be used with AppletType_Application.
+ */
+Result appletSelfExit(void);
+
+/**
  * @brief Processes the current applet status. Generally used within a main loop.
  * @return Whether the application should continue running.
  */

--- a/nx/source/services/applet.c
+++ b/nx/source/services/applet.c
@@ -1071,6 +1071,37 @@ Result appletSetScreenShotImageOrientation(s32 val) {
     return rc;
 }
 
+Result appletSelfExit(void) {
+    IpcCommand c;
+    ipcInitialize(&c);
+
+    struct {
+        u64 magic;
+        u64 cmd_id;
+    } *raw;
+
+    raw = ipcPrepareHeader(&c, sizeof(*raw));
+
+    raw->magic = SFCI_MAGIC;
+    raw->cmd_id = 0;
+
+    Result rc = serviceIpcDispatch(&g_appletISelfController);
+
+    if (R_SUCCEEDED(rc)) {
+        IpcParsedCommand r;
+        ipcParse(&r);
+
+        struct {
+            u64 magic;
+            u64 result;
+        } *resp = r.Raw;
+
+        rc = resp->result;
+    }
+
+    return rc;
+}
+
 Result appletCreateManagedDisplayLayer(u64 *out) {
     IpcCommand c;
     ipcInitialize(&c);


### PR DESCRIPTION
Add the [Exit](http://switchbrew.org/index.php/AM_services#Exit) command to applet. This enables exiting an application back to the home menu. It was named `appletSelfExit()` instead of `appletExit()` since `appletExit()` already existed.