### PR TITLE
hid: Call SetSupportedNpadStyleSet to enable additional Npad features

### DIFF
--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -592,6 +592,9 @@ void hidJoystickRead(JoystickPosition *pos, HidControllerID id, HidControllerJoy
 /// Returns 0 when CONTROLLER_PLAYER_1 is connected, otherwise returns 1 for handheld-mode.
 bool hidGetHandheldMode(void);
 
+/// Sets which controller types are supported. This is automatically called with all types in \ref hidInitialize.
+Result hidSetSupportedNpadStyleSet(HidControllerType type);
+
 /// Use this if you want to use a single joy-con as a dedicated CONTROLLER_PLAYER_*.
 /// When used, both joy-cons in a pair should be used with this (CONTROLLER_PLAYER_1 and CONTROLLER_PLAYER_2 for example).
 /// id must be CONTROLLER_PLAYER_*.

--- a/nx/source/services/hid.c
+++ b/nx/source/services/hid.c
@@ -73,6 +73,9 @@ Result hidInitialize(void)
     }
 
     if (R_SUCCEEDED(rc))
+        rc = hidSetSupportedNpadStyleSet(TYPE_PROCONTROLLER | TYPE_HANDHELD | TYPE_JOYCON_PAIR | TYPE_JOYCON_LEFT | TYPE_JOYCON_RIGHT);
+
+    if (R_SUCCEEDED(rc))
         rc = _hidSetDualModeAll();
 
     if (R_FAILED(rc))
@@ -523,6 +526,10 @@ static Result _hidCmdWithInputU32(u64 cmd_id, u32 inputval) {
     }
 
     return rc;
+}
+
+Result hidSetSupportedNpadStyleSet(HidControllerType type) {
+    return _hidCmdWithInputU32(100, type);
 }
 
 Result hidSetNpadJoyAssignmentModeSingleByDefault(HidControllerID id) {


### PR DESCRIPTION
This enables additional Npad features, so StartSixAxisSensor will actually do things other than just log timestamps.