### PR TITLE
add an exit request hook type, allow to delay exit

### DIFF
--- a/nx/include/switch/services/applet.h
+++ b/nx/include/switch/services/applet.h
@@ -27,6 +27,7 @@ typedef enum {
     AppletHookType_OnFocusState = 0,  ///< FocusState changed.
     AppletHookType_OnOperationMode,   ///< OperationMode changed.
     AppletHookType_OnPerformanceMode, ///< PerformanceMode changed.
+    AppletHookType_OnExitRequest,     ///< Exit requested.
 
     AppletHookType_Max,               ///< Number of applet hook types.
 } AppletHookType;
@@ -62,6 +63,12 @@ Result appletGetDesiredLanguage(u64 *LanguageCode);
 Result appletBeginBlockingHomeButton(s64 val);
 
 Result appletEndBlockingHomeButton(void);
+
+/**
+ * @brief Delay exiting until appletUnlockExit is called
+ */
+Result appletLockExit(void);
+Result appletUnlockExit(void);
 
 /**
  * @brief Controls whether screenshot-capture is allowed.

--- a/nx/source/services/applet.c
+++ b/nx/source/services/applet.c
@@ -1211,6 +1211,7 @@ bool appletMainLoop(void) {
     switch(msg) {
         case 0x4:
             appletCallHook(AppletHookType_OnExitRequest);
+            return false;
         break;
 
         case 0xF:

--- a/nx/source/services/applet.c
+++ b/nx/source/services/applet.c
@@ -71,8 +71,6 @@ static Result _appletSetOperationModeChangedNotification(u8 flag);
 static Result _appletSetPerformanceModeChangedNotification(u8 flag);
 
 static Result _appletSelfExit(void);
-//static Result _appletLockExit(void);
-//static Result _appletUnlockExit(void);
 //static Result _appletSetTerminateResult(Result res);
 
 static Result _appletExitProcessAndReturn(void);
@@ -895,13 +893,13 @@ static Result _appletSelfExit(void) {
     return _appletCmdNoIO(&g_appletISelfController, 0);
 }
 
-/*static Result _appletLockExit(void) {
+Result appletLockExit(void) {
     return _appletCmdNoIO(&g_appletISelfController, 1);
 }
 
-static Result _appletUnlockExit(void) {
+Result appletUnlockExit(void) {
     return _appletCmdNoIO(&g_appletISelfController, 2);
-}*/
+}
 
 Result appletSetScreenShotPermission(s32 val) {
     IpcCommand c;
@@ -1211,6 +1209,10 @@ bool appletMainLoop(void) {
     }
 
     switch(msg) {
+        case 0x4:
+            appletCallHook(AppletHookType_OnExitRequest);
+        break;
+
         case 0xF:
             rc = _appletGetCurrentFocusState(&g_appletFocusState);
             if (R_FAILED(rc))


### PR DESCRIPTION
This will permit to be able to be notified on exit by:
- hooking on exit
- being able to delay exit until decided

Here is an example of use: https://gist.github.com/p-sam/bd39c9a084cfd45c793d0bdfe2b8f2c7

Homebrew would be able to use this moment to flush state, and close handles. (eg: RetroArch flushing SaveRAM)