### PR TITLE
Make FS use domains.

### DIFF
--- a/nx/include/switch/services/sm.h
+++ b/nx/include/switch/services/sm.h
@@ -16,7 +16,7 @@ typedef enum {
     ServiceType_Normal,             ///< Normal service.
     ServiceType_Domain,             ///< Domain.
     ServiceType_DomainSubservice,   ///< Domain subservice;
-    ServiceType_Override            ///< Service overriden in the homebrew environment.
+    ServiceType_Override,           ///< Service overriden in the homebrew environment.
 } ServiceType;
 
 /// Service object structure.
@@ -114,14 +114,38 @@ static inline void serviceCreateDomainSubservice(Service* s, Service* parent, u3
 }
 
 /**
+ * @brief Creates a subservice object from a parent service.
+ * @param[out] s Service object.
+ * @param[in] parent Parent service, possibly a domain or domain subservice.
+ * @param[in] r Parsed IPC command containing handles/object IDs to create subservice from.
+ * @param[in] i The index of the handle/object ID to create subservice from.
+ */
+static inline void serviceCreateSubservice(Service* s, Service* parent, IpcParsedCommand* r, int i) {
+    if (r->IsDomainResponse) {
+        return serviceCreateDomainSubservice(s, parent, r->OutObjectIds[i]);
+    } else {
+        return serviceCreate(s, r->Handles[i]);
+    }
+}
+
+/**
  * @brief Converts a regular service to a domain.
  * @param[in] s Service object.
  * @return Result code.
  */
 static inline Result serviceConvertToDomain(Service* s) {
-    Result rc = ipcConvertSessionToDomain(s->handle, &s->object_id);
-    if(R_SUCCEEDED(rc))
+    Result rc = 0;
+    if (serviceIsOverride(s)) {
+        rc = ipcCloneSession(s->handle, 1, &s->handle);
+        if (R_FAILED(rc)) {
+            return rc;
+        }
+        s->type = ServiceType_Normal;
+    }
+    rc = ipcConvertSessionToDomain(s->handle, &s->object_id);
+    if (R_SUCCEEDED(rc)) {
         s->type = ServiceType_Domain;
+    }
     return rc;
 }
 
@@ -151,6 +175,37 @@ static inline void serviceClose(Service* s) {
     }
 
     s->type = ServiceType_Uninitialized;
+}
+
+
+
+/**
+ * @brief Prepares the header of an IPC command structure for a service.
+ * @param s Service to prepare message header for
+ * @param cmd IPC command structure.
+ * @param sizeof_raw Size in bytes of the raw data structure to embed inside the IPC request
+ * @return Pointer to the raw embedded data structure in the request, ready to be filled out.
+ */
+static inline void* serviceIpcPrepareHeader(Service* s, IpcCommand* cmd, size_t sizeof_raw) {
+    if (serviceIsDomain(s) || serviceIsDomainSubservice(s)) {
+        return ipcPrepareHeaderForDomain(cmd, sizeof_raw, serviceGetObjectId(s));
+    } else {
+        return ipcPrepareHeader(cmd, sizeof_raw);
+    }
+}
+
+/**
+ * @brief Parse an IPC command response into an IPC parsed command structure for a service.
+ * @param s Service to prepare message header for
+ * @param r IPC parsed command structure to fill in.
+ * @return Result code.
+ */
+static inline Result serviceIpcParse(Service* s, IpcParsedCommand* r, size_t sizeof_raw) {
+    if (serviceIsDomain(s) || serviceIsDomainSubservice(s)) {
+        return ipcParseDomainResponse(r, sizeof_raw);
+    } else {
+        return ipcParse(r);
+    }
 }
 
 /**

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -19,6 +19,10 @@ Result fsInitialize(void)
         return 0;
 
     Result rc = smGetService(&g_fsSrv, "fsp-srv");
+    
+    if (R_SUCCEEDED(rc)) {
+        rc = serviceConvertToDomain(&g_fsSrv);
+    }
 
     if (R_SUCCEEDED(rc)) {
         IpcCommand c;
@@ -31,7 +35,7 @@ Result fsInitialize(void)
             u64 unk;
         } *raw;
 
-        raw = ipcPrepareHeader(&c, sizeof(*raw));
+        raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
         raw->magic = SFCI_MAGIC;
         raw->cmd_id = 1;
@@ -41,12 +45,13 @@ Result fsInitialize(void)
 
         if (R_SUCCEEDED(rc)) {
             IpcParsedCommand r;
-            ipcParse(&r);
-
             struct {
                 u64 magic;
                 u64 result;
-            } *resp = r.Raw;
+            } *resp;
+
+            serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+            resp = r.Raw;
 
             rc = resp->result;
         }
@@ -75,7 +80,7 @@ Result fsOpenBisStorage(FsStorage* out, u32 PartitionId) {
         u32 PartitionId;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 12;
@@ -85,17 +90,18 @@ Result fsOpenBisStorage(FsStorage* out, u32 PartitionId) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -116,7 +122,7 @@ Result fsOpenBisFileSystem(FsFileSystem* out, u32 PartitionId, const char* strin
         u32 PartitionId;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 11;
@@ -126,17 +132,18 @@ Result fsOpenBisFileSystem(FsFileSystem* out, u32 PartitionId, const char* strin
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -152,7 +159,7 @@ Result fsMountSdcard(FsFileSystem* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 18;
@@ -161,17 +168,18 @@ Result fsMountSdcard(FsFileSystem* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -189,7 +197,7 @@ Result fsMountSaveData(FsFileSystem* out, u8 inval, FsSave *save) {
         FsSave save;
     } PACKED *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 51;
@@ -200,17 +208,18 @@ Result fsMountSaveData(FsFileSystem* out, u8 inval, FsSave *save) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -228,7 +237,7 @@ Result fsMountSystemSaveData(FsFileSystem* out, u8 inval, FsSave *save) {
         FsSave save;
     } PACKED *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 52;
@@ -239,17 +248,18 @@ Result fsMountSystemSaveData(FsFileSystem* out, u8 inval, FsSave *save) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -272,13 +282,13 @@ Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId) {
     } *raw2;
 
     if (SaveDataSpaceId == FsSaveDataSpaceId_All) {
-        raw = ipcPrepareHeader(&c, sizeof(*raw));
+        raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
         raw->magic = SFCI_MAGIC;
         raw->cmd_id = 60;
     }
     else {
-        raw2 = ipcPrepareHeader(&c, sizeof(*raw2));
+        raw2 = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw2));
 
         raw2->magic = SFCI_MAGIC;
         raw2->cmd_id = 61;
@@ -289,17 +299,18 @@ Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -315,7 +326,7 @@ Result fsOpenDataStorageByCurrentProcess(FsStorage* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 200;
@@ -324,17 +335,18 @@ Result fsOpenDataStorageByCurrentProcess(FsStorage* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -350,7 +362,7 @@ Result fsOpenDeviceOperator(FsDeviceOperator* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 400;
@@ -359,17 +371,18 @@ Result fsOpenDeviceOperator(FsDeviceOperator* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -385,7 +398,7 @@ Result fsOpenSdCardDetectionEventNotifier(FsEventNotifier* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 500;
@@ -394,17 +407,18 @@ Result fsOpenSdCardDetectionEventNotifier(FsEventNotifier* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -453,7 +467,7 @@ Result fsOpenFileSystemWithId(FsFileSystem* out, u64 titleId, FsFileSystemType f
             u64 titleId;
         } *raw;
     
-        raw = ipcPrepareHeader(&c, sizeof(*raw));
+        raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
     
         raw->magic = SFCI_MAGIC;
         raw->cmd_id = 8;
@@ -467,7 +481,7 @@ Result fsOpenFileSystemWithId(FsFileSystem* out, u64 titleId, FsFileSystemType f
             u32 fsType;
         } *raw;
     
-        raw = ipcPrepareHeader(&c, sizeof(*raw));
+        raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
     
         raw->magic = SFCI_MAGIC;
         raw->cmd_id = 0;
@@ -478,17 +492,18 @@ Result fsOpenFileSystemWithId(FsFileSystem* out, u64 titleId, FsFileSystemType f
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
         }
     }
 
@@ -509,7 +524,7 @@ Result fsFsCreateFile(FsFileSystem* fs, const char* path, size_t size, int flags
         u32 flags;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 0;
@@ -521,12 +536,13 @@ Result fsFsCreateFile(FsFileSystem* fs, const char* path, size_t size, int flags
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -544,7 +560,7 @@ Result fsFsDeleteFile(FsFileSystem* fs, const char* path) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 1;
@@ -553,12 +569,13 @@ Result fsFsDeleteFile(FsFileSystem* fs, const char* path) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -576,7 +593,7 @@ Result fsFsCreateDirectory(FsFileSystem* fs, const char* path) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 2;
@@ -585,12 +602,13 @@ Result fsFsCreateDirectory(FsFileSystem* fs, const char* path) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -608,7 +626,7 @@ Result fsFsDeleteDirectory(FsFileSystem* fs, const char* path) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 3;
@@ -617,12 +635,13 @@ Result fsFsDeleteDirectory(FsFileSystem* fs, const char* path) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -640,7 +659,7 @@ Result fsFsDeleteDirectoryRecursively(FsFileSystem* fs, const char* path) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 4;
@@ -649,12 +668,13 @@ Result fsFsDeleteDirectoryRecursively(FsFileSystem* fs, const char* path) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -673,7 +693,7 @@ Result fsFsRenameFile(FsFileSystem* fs, const char* path0, const char* path1) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 5;
@@ -682,12 +702,13 @@ Result fsFsRenameFile(FsFileSystem* fs, const char* path0, const char* path1) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -706,7 +727,7 @@ Result fsFsRenameDirectory(FsFileSystem* fs, const char* path0, const char* path
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 6;
@@ -715,12 +736,13 @@ Result fsFsRenameDirectory(FsFileSystem* fs, const char* path0, const char* path
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -738,7 +760,7 @@ Result fsFsGetEntryType(FsFileSystem* fs, const char* path, FsEntryType* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 7;
@@ -747,13 +769,14 @@ Result fsFsGetEntryType(FsFileSystem* fs, const char* path, FsEntryType* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u32 type;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
@@ -776,7 +799,7 @@ Result fsFsOpenFile(FsFileSystem* fs, const char* path, int flags, FsFile* out) 
         u32 flags;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 8;
@@ -786,17 +809,18 @@ Result fsFsOpenFile(FsFileSystem* fs, const char* path, int flags, FsFile* out) 
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &fs->s, &r, 0);
         }
     }
 
@@ -814,7 +838,7 @@ Result fsFsOpenDirectory(FsFileSystem* fs, const char* path, int flags, FsDir* o
         u32 flags;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 9;
@@ -824,17 +848,18 @@ Result fsFsOpenDirectory(FsFileSystem* fs, const char* path, int flags, FsDir* o
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &fs->s, &r, 0);
         }
     }
 
@@ -850,7 +875,7 @@ Result fsFsCommit(FsFileSystem* fs) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 10;
@@ -859,12 +884,13 @@ Result fsFsCommit(FsFileSystem* fs) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -882,7 +908,7 @@ Result fsFsGetFreeSpace(FsFileSystem* fs, const char* path, u64* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 11;
@@ -891,13 +917,14 @@ Result fsFsGetFreeSpace(FsFileSystem* fs, const char* path, u64* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u64 space;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
@@ -919,7 +946,7 @@ Result fsFsGetTotalSpace(FsFileSystem* fs, const char* path, u64* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 12;
@@ -928,13 +955,14 @@ Result fsFsGetTotalSpace(FsFileSystem* fs, const char* path, u64* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u64 space;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
@@ -956,7 +984,7 @@ Result fsFsCleanDirectoryRecursively(FsFileSystem* fs, const char* path) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&fs->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 13;
@@ -965,12 +993,13 @@ Result fsFsCleanDirectoryRecursively(FsFileSystem* fs, const char* path) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&fs->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -996,7 +1025,7 @@ Result fsFileRead(FsFile* f, u64 off, void* buf, size_t len, size_t* out) {
         u64 read_size;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&f->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 0;
@@ -1008,13 +1037,14 @@ Result fsFileRead(FsFile* f, u64 off, void* buf, size_t len, size_t* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u64 bytes_read;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&f->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
@@ -1039,7 +1069,7 @@ Result fsFileWrite(FsFile* f, u64 off, const void* buf, size_t len) {
         u64 write_size;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&f->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 1;
@@ -1051,12 +1081,13 @@ Result fsFileWrite(FsFile* f, u64 off, const void* buf, size_t len) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&f->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -1073,7 +1104,7 @@ Result fsFileFlush(FsFile* f) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&f->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 2;
@@ -1082,12 +1113,13 @@ Result fsFileFlush(FsFile* f) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&f->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -1105,7 +1137,7 @@ Result fsFileSetSize(FsFile* f, u64 sz) {
         u64 size;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&f->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 3;
@@ -1115,12 +1147,13 @@ Result fsFileSetSize(FsFile* f, u64 sz) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&f->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -1137,7 +1170,7 @@ Result fsFileGetSize(FsFile* f, u64* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&f->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 4;
@@ -1146,13 +1179,14 @@ Result fsFileGetSize(FsFile* f, u64* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u64 size;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&f->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
         if (R_SUCCEEDED(rc) && out) *out = resp->size;
@@ -1181,7 +1215,7 @@ Result fsDirRead(FsDir* d, u64 inval, size_t* total_entries, size_t max_entries,
         u64 inval;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&d->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 0;
@@ -1191,13 +1225,14 @@ Result fsDirRead(FsDir* d, u64 inval, size_t* total_entries, size_t max_entries,
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u64 total_entries;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&d->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
@@ -1218,7 +1253,7 @@ Result fsDirGetEntryCount(FsDir* d, u64* count) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&d->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 1;
@@ -1227,13 +1262,14 @@ Result fsDirGetEntryCount(FsDir* d, u64* count) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u64 count;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&d->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
         if (R_SUCCEEDED(rc) && count) *count = resp->count;
@@ -1255,7 +1291,7 @@ Result fsStorageRead(FsStorage* s, u64 off, void* buf, size_t len) {
         u64 read_size;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&s->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 0;
@@ -1266,12 +1302,13 @@ Result fsStorageRead(FsStorage* s, u64 off, void* buf, size_t len) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&s->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -1291,7 +1328,7 @@ Result fsStorageWrite(FsStorage* s, u64 off, const void* buf, size_t len) {
         u64 write_size;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&s->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 1;
@@ -1302,12 +1339,13 @@ Result fsStorageWrite(FsStorage* s, u64 off, const void* buf, size_t len) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&s->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -1324,7 +1362,7 @@ Result fsStorageFlush(FsStorage* s) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&s->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 2;
@@ -1333,12 +1371,13 @@ Result fsStorageFlush(FsStorage* s) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&s->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -1356,7 +1395,7 @@ Result fsStorageSetSize(FsStorage* s, u64 sz) {
         u64 size;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&s->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 3;
@@ -1366,12 +1405,13 @@ Result fsStorageSetSize(FsStorage* s, u64 sz) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&s->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }
@@ -1388,7 +1428,7 @@ Result fsStorageGetSize(FsStorage* s, u64* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&s->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 4;
@@ -1397,13 +1437,14 @@ Result fsStorageGetSize(FsStorage* s, u64* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u64 size;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&s->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
         if (R_SUCCEEDED(rc) && out) *out = resp->size;
@@ -1427,7 +1468,7 @@ Result fsSaveDataIteratorRead(FsSaveDataIterator *s, FsSaveDataInfo* buf, size_t
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&s->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 0;
@@ -1436,13 +1477,14 @@ Result fsSaveDataIteratorRead(FsSaveDataIterator *s, FsSaveDataInfo* buf, size_t
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u64 total_entries;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&s->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
@@ -1468,7 +1510,7 @@ Result fsEventNotifierGetEventHandle(FsEventNotifier* e, Handle* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&e->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 0;
@@ -1477,12 +1519,13 @@ Result fsEventNotifierGetEventHandle(FsEventNotifier* e, Handle* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&e->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 
@@ -1508,7 +1551,7 @@ Result fsDeviceOperatorIsSdCardInserted(FsDeviceOperator* d, bool* out) {
         u64 cmd_id;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&d->s, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 0;
@@ -1517,13 +1560,14 @@ Result fsDeviceOperatorIsSdCardInserted(FsDeviceOperator* d, bool* out) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u8 is_inserted;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&d->s, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
 

--- a/nx/source/services/fsldr.c
+++ b/nx/source/services/fsldr.c
@@ -21,6 +21,10 @@ Result fsldrInitialize(void) {
         return 0;
 
     Result rc = smGetService(&g_fsldrSrv, "fsp-ldr");
+    
+    if (R_SUCCEEDED(rc)) {
+        rc = serviceConvertToDomain(&g_fsldrSrv);
+    }
 
     if (R_SUCCEEDED(rc) && kernelAbove400()) {
         rc = fsldrSetCurrentProcess();
@@ -47,7 +51,7 @@ Result fsldrOpenCodeFileSystem(u64 tid, const char *path, FsFileSystem* out) {
         u64 tid;
     } *raw;
     
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsldrSrv, &c, sizeof(*raw));
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 0;
     raw->tid = tid;
@@ -57,17 +61,18 @@ Result fsldrOpenCodeFileSystem(u64 tid, const char *path, FsFileSystem* out) {
     
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsldrSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
         
         if (R_SUCCEEDED(rc)) {
-            serviceCreate(&out->s, r.Handles[0]);
+            serviceCreateSubservice(&out->s, &g_fsldrSrv, &r, 0);
         }
     }
     
@@ -84,7 +89,7 @@ Result fsldrIsArchivedProgram(u64 pid, bool *out) {
         u64 pid;
     } *raw;
     
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsldrSrv, &c, sizeof(*raw));
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 1;
     raw->pid = pid;
@@ -93,13 +98,14 @@ Result fsldrIsArchivedProgram(u64 pid, bool *out) {
     
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
             u8 is_archived;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsldrSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
         
@@ -122,7 +128,7 @@ Result fsldrSetCurrentProcess(void) {
         u64 unk;
     } *raw;
 
-    raw = ipcPrepareHeader(&c, sizeof(*raw));
+    raw = serviceIpcPrepareHeader(&g_fsldrSrv, &c, sizeof(*raw));
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 2;
@@ -132,12 +138,13 @@ Result fsldrSetCurrentProcess(void) {
 
     if (R_SUCCEEDED(rc)) {
         IpcParsedCommand r;
-        ipcParse(&r);
-
         struct {
             u64 magic;
             u64 result;
-        } *resp = r.Raw;
+        } *resp;
+
+        serviceIpcParse(&g_fsldrSrv, &r, sizeof(*resp));
+        resp = r.Raw;
 
         rc = resp->result;
     }


### PR DESCRIPTION
Adds new serviceIpcPrepareHeader, serviceIpcParse, serviceCreateSubservice functions.

Causes a breaking (but necessary) change to ipcParseForDomain.

Makes fsInitialize() call serviceConvertToDomain(), resulting in all FS commands using domain object IDs.