### PR TITLE
netinet: fix missing declarations (?)

### DIFF
--- a/nx/external/bsd/include/netinet/in.h
+++ b/nx/external/bsd/include/netinet/in.h
@@ -45,6 +45,15 @@
 #include <sys/types.h>
 #include <machine/endian.h>
 
+#ifndef _IN_ADDR_T_DECLARED
+typedef	__uint32_t	in_addr_t;
+#define	_IN_ADDR_T_DECLARED
+#endif
+#ifndef _IN_PORT_T_DECLARED
+typedef	__uint16_t	in_port_t;
+#define	_IN_PORT_T_DECLARED
+#endif
+
 /* Protocols common to RFC 1700, POSIX, and X/Open. */
 #define	IPPROTO_IP		0		/* dummy for IP */
 #define	IPPROTO_ICMP		1		/* control message protocol */
@@ -70,15 +79,6 @@ struct in_addr {
 #ifndef	_SOCKLEN_T_DECLARED
 typedef	__socklen_t	socklen_t;
 #define	_SOCKLEN_T_DECLARED
-#endif
-
-#ifndef _IN_ADDR_T_DECLARED
-typedef	__uint32_t	in_addr_t;
-#define	_IN_ADDR_T_DECLARED
-#endif
-#ifndef _IN_PORT_T_DECLARED
-typedef	__uint16_t	in_port_t;
-#define	_IN_PORT_T_DECLARED
 #endif
 
 #include <sys/_sockaddr_storage.h>

--- a/nx/external/bsd/include/netinet/in.h
+++ b/nx/external/bsd/include/netinet/in.h
@@ -72,6 +72,15 @@ typedef	__socklen_t	socklen_t;
 #define	_SOCKLEN_T_DECLARED
 #endif
 
+#ifndef _IN_ADDR_T_DECLARED
+typedef	__uint32_t	in_addr_t;
+#define	_IN_ADDR_T_DECLARED
+#endif
+#ifndef _IN_PORT_T_DECLARED
+typedef	__uint16_t	in_port_t;
+#define	_IN_PORT_T_DECLARED
+#endif
+
 #include <sys/_sockaddr_storage.h>
 
 /* Socket address, internet style. */


### PR DESCRIPTION
I'm not sure what is the cause of this missing declarations, as they are defined in <sys/types.h>. What i know for sure is this commit fix a few library/application build i'm currently using privately.