### PR TITLE
fix print \n twice

### DIFF
--- a/nx/source/runtime/devices/console.c
+++ b/nx/source/runtime/devices/console.c
@@ -625,7 +625,8 @@ void consolePrintChar(int c) {
 	if(currentConsole->cursorX  >= currentConsole->windowWidth) {
 		currentConsole->cursorX  = 0;
 
-		consoleNewRow();
+		if (c != '\n')
+			consoleNewRow();
 	}
 
 	switch(c) {


### PR DESCRIPTION
if '\n' is printed at windowWidth + 1, consoleNewRow() will be executed twice.

Example:

```
printf("%s\n", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

```

80 'a' will be printed, then new line because the cursor is a the end of the line, and then our '\n' will be printed
