### PR TITLE
fs: Add fsFsQueryEntry (and fsFsSetArchiveBit helper)

### DIFF
--- a/nx/include/switch/runtime/devices/fs_dev.h
+++ b/nx/include/switch/runtime/devices/fs_dev.h
@@ -42,5 +42,8 @@ FsFileSystem* fsdevGetDeviceFileSystem(const char *name);
 /// Returns the FsFileSystem for the default device (SD card), if mounted. Used internally by romfs_dev.
 FsFileSystem* fsdevGetDefaultFileSystem(void);
 
+/// This calls fsFsSetArchiveBit on the filesystem specified by the input absolute path. 
+Result fsdevSetArchiveBit(const char *path);
+
 /// Unmounts all devices and cleans up any resources used by the FS driver.
 Result fsdevUnmountAll(void);

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -204,7 +204,6 @@ Result fsFsGetTotalSpace(FsFileSystem* fs, const char* path, u64* out);
 Result fsFsCleanDirectoryRecursively(FsFileSystem* fs, const char* path);
 Result fsFsQueryEntry(FsFileSystem* fs, void *out, size_t out_size, const void *in, size_t in_size, const char* path, FsFileSystemQueryType query_type);
 Result fsFsSetArchiveBit(FsFileSystem* fs, const char *path);
-
 void fsFsClose(FsFileSystem* fs);
 
 // IFile

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -206,7 +206,7 @@ Result fsFsQueryEntry(FsFileSystem* fs, void *out, size_t out_size, const void *
 void fsFsClose(FsFileSystem* fs);
 
 /// Uses fsFsQueryEntry to set the archive bit on the specified absolute directory path.
-/// This will cause HOS to treat the directory as though it is a file containing the directory's concatenated contents.
+/// This will cause HOS to treat the directory as if it were a file containing the directory's concatenated contents.
 Result fsFsSetArchiveBit(FsFileSystem* fs, const char *path);
 
 // IFile

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -203,8 +203,11 @@ Result fsFsGetFreeSpace(FsFileSystem* fs, const char* path, u64* out);
 Result fsFsGetTotalSpace(FsFileSystem* fs, const char* path, u64* out);
 Result fsFsCleanDirectoryRecursively(FsFileSystem* fs, const char* path);
 Result fsFsQueryEntry(FsFileSystem* fs, void *out, size_t out_size, const void *in, size_t in_size, const char* path, FsFileSystemQueryType query_type);
-Result fsFsSetArchiveBit(FsFileSystem* fs, const char *path);
 void fsFsClose(FsFileSystem* fs);
+
+/// Uses fsFsQueryEntry to set the archive bit on the specified absolute directory path.
+/// This will cause HOS to treat the directory as though it is a file containing the directory's concatenated contents.
+Result fsFsSetArchiveBit(FsFileSystem* fs, const char *path);
 
 // IFile
 Result fsFileRead(FsFile* f, u64 off, void* buf, size_t len, size_t* out);

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -178,6 +178,11 @@ typedef enum
     FsFileSystemType_ApplicationPackage = 7
 } FsFileSystemType;
 
+typedef enum
+{
+    FsFileSystemQueryType_SetArchiveBit = 0,
+} FsFileSystemQueryType;
+
 /// Mount requested filesystem type from content file
 Result fsOpenFileSystem(FsFileSystem* out, FsFileSystemType fsType, const char* contentPath); /// same as calling fsOpenFileSystemWithId with 0 as titleId
 Result fsOpenFileSystemWithId(FsFileSystem* out, u64 titleId, FsFileSystemType fsType, const char* contentPath); /// works on all firmwares, titleId is ignored on 1.0.0
@@ -197,6 +202,9 @@ Result fsFsCommit(FsFileSystem* fs);
 Result fsFsGetFreeSpace(FsFileSystem* fs, const char* path, u64* out);
 Result fsFsGetTotalSpace(FsFileSystem* fs, const char* path, u64* out);
 Result fsFsCleanDirectoryRecursively(FsFileSystem* fs, const char* path);
+Result fsFsQueryEntry(FsFileSystem* fs, void *out, size_t out_size, const void *in, size_t in_size, const char* path, FsFileSystemQueryType query_type);
+Result fsFsSetArchiveBit(FsFileSystem* fs, const char *path);
+
 void fsFsClose(FsFileSystem* fs);
 
 // IFile

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -369,13 +369,13 @@ Result fsdevCommitDevice(const char *name)
 }
 
 Result fsdevSetArchiveBit(const char *path) {
-  fsdev_fsdevice *device;
+  char          fs_path[FS_MAX_PATH];
+  fsdev_fsdevice *device = NULL;
 
-  device = fsdevFindDevice(path);
-  if(device==NULL)
+  if(fsdev_getfspath(_REENT, path, &device, fs_path)==-1)
     return MAKERESULT(Module_Libnx, LibnxError_NotFound);
 
-  return fsFsSetArchiveBit(&device->fs, path);
+  return fsFsSetArchiveBit(&device->fs, fs_path);
 }
 
 /*! Initialize SDMC device */

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -368,6 +368,16 @@ Result fsdevCommitDevice(const char *name)
   return fsFsCommit(&device->fs);
 }
 
+Result fsdevSetArchiveBit(const char *path) {
+  fsdev_fsdevice *device;
+
+  device = fsdevFindDevice(path);
+  if(device==NULL)
+    return MAKERESULT(Module_Libnx, LibnxError_NotFound);
+
+  return fsFsSetArchiveBit(&device->fs, path);
+}
+
 /*! Initialize SDMC device */
 Result fsdevMountSdmc(void)
 {

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -1008,6 +1008,9 @@ Result fsFsCleanDirectoryRecursively(FsFileSystem* fs, const char* path) {
 }
 
 Result fsFsQueryEntry(FsFileSystem* fs, void *out, size_t out_size, const void *in, size_t in_size, const char* path, FsFileSystemQueryType query_type) {
+    if (!kernelAbove400())
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
     char send_path[FS_MAX_PATH] = {0};
     strncpy(send_path, path, sizeof(send_path)-1);
 


### PR DESCRIPTION
This adds fsFsQueryEntry, an IFileSystem command added in 4.0.0.

It also adds a helper for using fsFsQueryEntry to set the archive bit. Please note, HOS returns 0x202 when calling SetArchiveBit on a file (and only allows setting on directories). This should be fine, though, because HOS only assigns special meaning to the archive bit for directories.