### PR TITLE
Add missing applet focus states and handling modes

### DIFF
--- a/nx/include/switch/services/applet.h
+++ b/nx/include/switch/services/applet.h
@@ -35,18 +35,18 @@ typedef enum {
 } AppletHookType;
 
 typedef enum {
-    AppletFocusState_Focused = 1,               ///< Applet is focused.
-    AppletFocusState_NotFocusedUnknown = 2,     ///< Out of focus - unknown reason (LibraryApplet open?).
-    AppletFocusState_NotFocusedHomeSleep = 3    ///< Out of focus - HOME menu is open / console is sleeping.
+    AppletFocusState_Focused = 1,                   ///< Applet is focused.
+    AppletFocusState_NotFocusedLibraryApplet = 2,   ///< Out of focus - LibraryApplet open.
+    AppletFocusState_NotFocusedHomeSleep = 3        ///< Out of focus - HOME menu open / console is sleeping.
 } AppletFocusState;
 
 typedef enum {
-  AppletFocusHandlingMode_Suspend1 = 0, ///< Suspend when out of focus.
-  AppletFocusHandlingMode_NoSuspend,    ///< Don't suspend when out of focus.
-  AppletFocusHandlingMode_Suspend2,     ///< Suspend when out of focus (unknown variant 1).
-  AppletFocusHandlingMode_Suspend3,     ///< Suspend when out of focus (unknown variant 2).
+  AppletFocusHandlingMode_SuspendHomeSleep = 0,       ///< Suspend only when HOME menu is open / console is sleeping (default).
+  AppletFocusHandlingMode_NoSuspend,                  ///< Don't suspend when out of focus.
+  AppletFocusHandlingMode_SuspendHomeSleepNotify,     ///< Suspend only when HOME menu is open / console is sleeping but still receive OnFocusState hook.
+  AppletFocusHandlingMode_AlwaysSuspend,              ///< Always suspend when out of focus, regardless of the reason.
 
-  AppletFocusHandlingMode_Max,          //< Number of focus handling modes
+  AppletFocusHandlingMode_Max,                        ///< Number of focus handling modes.
 } AppletFocusHandlingMode;
 
 typedef enum {

--- a/nx/source/services/applet.c
+++ b/nx/source/services/applet.c
@@ -227,7 +227,7 @@ Result appletInitialize(void)
             rc = _appletAcquireForegroundRights();
 
         if (R_SUCCEEDED(rc))
-            rc = appletSetFocusHandlingMode(AppletFocusHandlingMode_Suspend1);
+            rc = appletSetFocusHandlingMode(AppletFocusHandlingMode_SuspendHomeSleep);
     }
 
     if (R_SUCCEEDED(rc) && __nx_applet_auto_notifyrunning)
@@ -393,13 +393,13 @@ Result appletSetFocusHandlingMode(AppletFocusHandlingMode mode) {
 
     memset(invals, 0, sizeof(invals));
 
-    if ((mode == AppletFocusHandlingMode_Suspend1) || (mode == AppletFocusHandlingMode_Suspend3)) {
+    if ((mode == AppletFocusHandlingMode_SuspendHomeSleep) || (mode == AppletFocusHandlingMode_AlwaysSuspend)) {
         invals[0] = 0;
         invals[1] = 0;
         invals[2] = 1;
     }
 
-    if (mode != AppletFocusHandlingMode_Suspend3) {
+    if (mode != AppletFocusHandlingMode_AlwaysSuspend) {
         invals[3] = 0;
 
         if (mode == AppletFocusHandlingMode_NoSuspend) {
@@ -407,7 +407,7 @@ Result appletSetFocusHandlingMode(AppletFocusHandlingMode mode) {
             invals[1] = 1;
             invals[2] = 0;
         }
-        else if (mode == AppletFocusHandlingMode_Suspend2) {
+        else if (mode == AppletFocusHandlingMode_SuspendHomeSleepNotify) {
             invals[0] = 1;
             invals[1] = 0;
             invals[2] = 1;


### PR DESCRIPTION
I added the missing applet focus states and handling modes in `applet.h`.

- The unknown focus state is indeed because of an open LibraryApplet
- Suspend1 is now SuspendHomeSleep, as it only suspends when the HOME menu is open or the console is sleeping
- Suspend2 is now SuspendHomeSleepNotify, as it only suspends when the HOME menu is open or the console is sleeping while still recieving the OnFocusState hook
- Suspend3 is now AlwaysSuspend, as it always suspends the applet regardless of the reason (HOME menu or LibraryApplet)