### PR TITLE
redirect sys/poll.h to poll.h for compatibility

### DIFF
--- a/nx/external/bsd/include/sys/poll.h
+++ b/nx/external/bsd/include/sys/poll.h
@@ -1,0 +1,2 @@
+#include <poll.h>
+


### PR DESCRIPTION
See https://github.com/devkitPro/pacman-packages/pull/62#discussion_r241958388 for reasoning. linux and osx have both headers which means some software will be easier to port if we have both headers too.