### PR TITLE
Mutex Error Checking

### DIFF
--- a/nx/include/switch/kernel/mutex.h
+++ b/nx/include/switch/kernel/mutex.h
@@ -26,8 +26,9 @@ static inline void mutexInit(Mutex* m)
 /**
  * @brief Locks a mutex.
  * @param m Mutex object.
+ * @return 0 if the mutex is already owned by this thread, and 1 if it was sucessfully acquired.
  */
-void mutexLock(Mutex* m);
+bool mutexLock(Mutex* m);
 
 /**
  * @brief Attempts to lock a mutex without waiting.
@@ -39,8 +40,9 @@ bool mutexTryLock(Mutex* m);
 /**
  * @brief Unlocks a mutex.
  * @param m Mutex object.
+ * @return 1 if the mutex was released, and 0 if the mutex does not belong to this thread.
  */
-void mutexUnlock(Mutex* m);
+bool mutexUnlock(Mutex* m);
 
 /**
  * @brief Initializes a recursive mutex.

--- a/nx/source/kernel/mutex.c
+++ b/nx/source/kernel/mutex.c
@@ -12,7 +12,7 @@ static u32 _GetTag(void) {
 bool mutexLock(Mutex* m) {
     u32 self = _GetTag();
 
-    bool first = false;
+    bool first = true;
     while (1) {
         u32 cur = __sync_val_compare_and_swap((u32*)m, 0, self);
 
@@ -40,7 +40,7 @@ bool mutexLock(Mutex* m) {
             }
         }
 
-        first = true;
+        first = false;
     }
 }
 


### PR DESCRIPTION
I'm currently trying to implement pthreads as good as possible (or rather as good as I'm eable to pull off). To implement all [mutex types](https://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_mutex_lock.html), I need to know whether a mutex is already owned by the current thread when locking it, aswell as if it even belongs to the current thread, when unlocking.