### PR TITLE
Implement a way to set the NRO that the next NRO will return to

### DIFF
--- a/nx/include/switch/runtime/env.h
+++ b/nx/include/switch/runtime/env.h
@@ -34,6 +34,7 @@ enum {
     EntryType_ProcessHandle=10,       ///< Provides the process handle.
     EntryType_LastLoadResult=11,      ///< Provides the last load result.
     EntryType_RandomSeed=14,          ///< Provides random data used to seed the pseudo-random number generator.
+    EntryType_NroReturnPath=15
 };
 
 enum {
@@ -93,6 +94,12 @@ Result envSetNextLoad(const char* path, const char* argv);
 
 /// Returns true if the environment supports envSetNextLoad.
 bool envHasNextLoad(void);
+
+/// Sets the path of the NRO that will be loaded after the next one
+Result envSetNroReturnPath(const char* path);
+
+///Returns true if the environment supports envSetNroReturnPath
+bool envHasNroReturnPath(void);
 
 /// Returns the Result from the last NRO.
 Result envGetLastLoadResult(void);

--- a/nx/source/runtime/env.c
+++ b/nx/source/runtime/env.c
@@ -17,6 +17,7 @@ static u64    g_syscallHints[2];
 static Handle g_processHandle = INVALID_HANDLE;
 static char*  g_nextLoadPath = NULL;
 static char*  g_nextLoadArgv = NULL;
+static char*  g_nroReturnPath=NULL;
 static Result g_lastLoadResult = 0;
 static bool   g_hasRandomSeed = false;
 static u64    g_randomSeed[2] = { 0, 0 };
@@ -97,6 +98,10 @@ void envSetup(void* ctx, Handle main_thread, LoaderReturnFn saved_lr)
             g_hasRandomSeed = true;
             g_randomSeed[0] = ent->Value[0];
             g_randomSeed[1] = ent->Value[1];
+            break;
+
+        case EntryType_NroReturnPath:
+            g_nroReturnPath = (char*) ent->Value[0];
             break;
 
         default:
@@ -182,6 +187,19 @@ Result envSetNextLoad(const char* path, const char* argv)
 
 bool envHasNextLoad(void) {
     return g_nextLoadPath != NULL;
+}
+
+Result envSetNroReturnPath(const char* path) {
+    if (g_nroReturnPath == NULL)
+        return MAKERESULT(Module_Libnx, LibnxError_NotInitialized);
+
+    strcpy(g_nroReturnPath, path);
+
+    return 0;
+}
+
+bool envHasNroReturnPath(void) {
+    return g_nroReturnPath!=NULL;
 }
 
 Result envGetLastLoadResult(void) {


### PR DESCRIPTION
This is to be used with [my fork of nx-hbloader](https://github.com/friedkeenan/nx-hbloader) (Pull request [here](https://github.com/switchbrew/nx-hbloader/pull/12)).

I made this in about 3 and a half hours while tired, so please cut me some slack if I did anything absolutely terribly.

You can see a simple example [here](https://gist.github.com/friedkeenan/fdef33762dbd3f5e09cea8b6d7ad38f0).

The variable and function names aren't very good in my opinion, but I didn't know what else to call them.

I mainly did this because I thought it was not ideal that [Goldleaf](https://github.com/XorTroll/Goldleaf) had to return to the homebrew menu after launching an NRO, and couldn't return back to itself.