### PR TITLE
pm: Add pmdmntGetServiceSession()

### DIFF
--- a/nx/include/switch/services/pm.h
+++ b/nx/include/switch/services/pm.h
@@ -9,6 +9,7 @@
 #pragma once
 #include "../types.h"
 #include "../kernel/event.h"
+#include "../services/sm.h"
 
 typedef enum {
     PmLaunchFlag_None           = 0,
@@ -47,6 +48,8 @@ typedef struct {
 
 Result pmdmntInitialize(void);
 void pmdmntExit(void);
+
+Service* pmdmntGetServiceSession(void);
 
 Result pminfoInitialize(void);
 void pminfoExit(void);

--- a/nx/source/services/pm.c
+++ b/nx/source/services/pm.c
@@ -27,6 +27,10 @@ void pmdmntExit(void)
     }
 }
 
+Service* pmdmntGetServiceSession(void) {
+    return &g_pmdmntSrv;
+}
+
 Result pminfoInitialize(void)
 {
     atomicIncrement64(&g_pminfoRefCnt);


### PR DESCRIPTION
This is necessary in order to support a shim for service extension without having two sessions active.