### PR TITLE
hwopus: Document second member of HwopusHeader

### DIFF
--- a/nx/include/switch/services/hwopus.h
+++ b/nx/include/switch/services/hwopus.h
@@ -18,8 +18,8 @@ typedef struct {
 /// This structure is the start of opusin for \ref hwopusDecodeInterleaved, with the actual opus packet following this.
 /// These fields are big-endian.
 typedef struct {
-    u32 size; ///< Size of the packet following this header.
-    u32 unk;  ///< Unknown, can be left at zero.
+    u32 size;        ///< Size of the packet following this header.
+    u32 final_range; ///< Indicates the final range of the codec encoder's entropy coder. This can be left at zero.
 } HwopusHeader;
 
 /// Used internally.


### PR DESCRIPTION
This second member indicates the Opus encoder's entropy coder's final range. While nothing in the service actually does anything with the final range as far as I can tell, this is specified within [RFC 6716](https://tools.ietf.org/html/rfc6716) (see section "6. Conformance") as a means of ensuring decoder conformance. It states as follows:

>
> In addition, a compliant decoder implementation MUST have
> the same final range decoder state as that of the reference decoder.
>

So what is likely done when performing compliance testing is the data is encoded, and then the final range of the encoder is sent via this header, then during decoding, the final range would be checked against to ensure that it's valid (though this doesn't seem to actually be checked anywhere in the hwopus-related code in the service on hardware; at least not yet anyways).