### PR TITLE
romfs: refactor to allow specifying mount name

### DIFF
--- a/nx/include/switch/runtime/devices/romfs_dev.h
+++ b/nx/include/switch/runtime/devices/romfs_dev.h
@@ -50,49 +50,45 @@ typedef struct
     uint8_t name[];   ///< Name. (UTF-8)
 } romfs_file;
 
-struct romfs_mount;
-
 /**
  * @brief Mounts the Application's RomFS.
- * @param mount Output mount handle
+ * @param name Device mount name.
  */
-Result romfsMount(struct romfs_mount **mount);
+Result romfsMount(const char *name);
 static inline Result romfsInit(void)
 {
-    return romfsMount(NULL);
+    return romfsMount("romfs");
 }
 
 /**
  * @brief Mounts RomFS from an open file.
  * @param file FsFile of the RomFS image.
  * @param offset Offset of the RomFS within the file.
- * @param mount Output mount handle
+ * @param name Device mount name.
  */
-Result romfsMountFromFile(FsFile file, u64 offset, struct romfs_mount **mount);
+Result romfsMountFromFile(FsFile file, u64 offset, const char *name);
 static inline Result romfsInitFromFile(FsFile file, u64 offset)
 {
-    return romfsMountFromFile(file, offset, NULL);
+    return romfsMountFromFile(file, offset, "romfs");
 }
 
 /**
  * @brief Mounts RomFS from an open storage.
  * @param storage FsStorage of the RomFS image.
  * @param offset Offset of the RomFS within the storage.
- * @param mount Output mount handle
+ * @param name Device mount name.
  */
-Result romfsMountFromStorage(FsStorage storage, u64 offset, struct romfs_mount **mount);
+Result romfsMountFromStorage(FsStorage storage, u64 offset, const char *name);
 static inline Result romfsInitFromStorage(FsStorage storage, u64 offset)
 {
-    return romfsMountFromStorage(storage, offset, NULL);
+    return romfsMountFromStorage(storage, offset, "romfs");
 }
 
-/// Bind the RomFS mount
-Result romfsBind(struct romfs_mount *mount);
 
 /// Unmounts the RomFS device.
-Result romfsUnmount(struct romfs_mount *mount);
+Result romfsUnmount(const char *name);
 static inline Result romfsExit(void)
 {
-    return romfsUnmount(NULL);
+    return romfsUnmount("romfs");
 }
 

--- a/nx/include/switch/runtime/devices/romfs_dev.h
+++ b/nx/include/switch/runtime/devices/romfs_dev.h
@@ -84,6 +84,13 @@ static inline Result romfsInitFromStorage(FsStorage storage, u64 offset)
     return romfsMountFromStorage(storage, offset, "romfs");
 }
 
+/**
+ * @brief Mounts RomFS from a system data archive.
+ * @param dataId Title ID of system data archive to mount.
+ * @param storageId Storage ID to mount from.
+ * @param name Device mount name.
+ */
+Result romfsMountFromDataArchive(u64 dataId, FsStorageId storageId, const char *name);
 
 /// Unmounts the RomFS device.
 Result romfsUnmount(const char *name);

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -175,6 +175,7 @@ Result fsMountSaveData(FsFileSystem* out, u8 inval, FsSave *save);
 Result fsMountSystemSaveData(FsFileSystem* out, u8 inval, FsSave *save);
 Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId);
 Result fsOpenDataStorageByCurrentProcess(FsStorage* out);
+Result fsOpenDataStorageByDataId(FsStorage* out, u64 dataId, FsStorageId storageId);
 Result fsOpenDeviceOperator(FsDeviceOperator* out);
 Result fsOpenSdCardDetectionEventNotifier(FsEventNotifier* out);
 // todo: Rest of commands here

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -283,13 +283,14 @@ static int _fsdevMountDevice(const char *name, FsFileSystem fs, fsdev_fsdevice *
 {
   fsdev_fsdevice *device = NULL;
 
+  _fsdevInit(); //Ensure fsdev is initialized
+
   if(fsdevFindDevice(name)) //Device is already mounted with the same name.
   {
     fsFsClose(&fs);
     return -1;
   }
 
-  _fsdevInit(); //Ensure fsdev is initialized
   device = fsdevFindDevice(NULL);
   if(device==NULL)
   {

--- a/nx/source/runtime/devices/romfs_dev.c
+++ b/nx/source/runtime/devices/romfs_dev.c
@@ -305,7 +305,16 @@ Result romfsMountFromStorage(FsStorage storage, u64 offset, const char *name)
     mount->offset = offset;
 
     return romfsMountCommon(name, mount);
+}
 
+Result romfsMountFromDataArchive(u64 dataId, FsStorageId storageId, const char *name) {
+    FsStorage storage;
+
+    Result rc = fsOpenDataStorageByDataId(&storage, dataId, storageId);
+    if (R_FAILED(rc))
+        return rc;
+
+    return romfsMountFromStorage(storage, 0, name);
 }
 
 Result romfsMountCommon(const char *name, romfs_mount *mount)


### PR DESCRIPTION
This re-does the romfs API to allow specifying mount name.

It also adds a helper for mounting a system data archive, and fsOpenDataStorageByDataId.