### PR TITLE
kernel/ipc: Resolve missing initializer warnings

### DIFF
--- a/nx/include/switch/kernel/ipc.h
+++ b/nx/include/switch/kernel/ipc.h
@@ -98,7 +98,7 @@ typedef struct {
  * @param cmd IPC command structure.
  */
 static inline void ipcInitialize(IpcCommand* cmd) {
-    *cmd = (IpcCommand){0};
+    *cmd = (IpcCommand){};
 }
 
 /// IPC buffer descriptor.


### PR DESCRIPTION
In C++ projects with higher warning levels, this header can cause some missing initializer warnings to leak over. This silences those from occurring.