### PR TITLE
Implement svcQueryProcessMemory

### DIFF
--- a/nx/include/switch/kernel/svc.h
+++ b/nx/include/switch/kernel/svc.h
@@ -1057,6 +1057,18 @@ Result svcMapProcessMemory(void* dst, Handle proc, u64 src, u64 size);
 Result svcUnmapProcessMemory(void* dst, Handle proc, u64 src, u64 size);
 
 /**
+ * @brief Equivalent to \ref svcQueryMemory, for another process.
+ * @param[out] meminfo_ptr \ref MemoryInfo structure which will be filled in.
+ * @param[out] pageinfo Page information which will be filled in.
+ * @param[in] proc Process handle.
+ * @param[in] addr Address to query.
+ * @return Result code.
+ * @note Syscall number 0x76.
+ * @warning This is a privileged syscall. Use \ref envIsSyscallHinted to check if it is available.
+ */
+Result svcQueryProcessMemory(MemoryInfo* meminfo_ptr, u32 *pageinfo, Handle proc, u64 addr);
+
+/**
  * @brief Maps normal heap in a certain process as executable code (used when loading NROs).
  * @param[in] proc Process handle (cannot be \ref CUR_PROCESS_HANDLE).
  * @param[in] dst Destination mapping address.

--- a/nx/source/kernel/svc.s
+++ b/nx/source/kernel/svc.s
@@ -572,6 +572,14 @@ SVC_BEGIN svcUnmapProcessMemory
 	ret
 SVC_END
 
+SVC_BEGIN svcQueryProcessMemory
+	str x1, [sp, #-16]!
+	svc 0x76
+	ldr x2, [sp], #16
+	str w1, [x2]
+	ret
+SVC_END
+
 SVC_BEGIN svcMapProcessCodeMemory
 	svc 0x77
 	ret


### PR DESCRIPTION
how do we still have unimplemented svcs in 2019