### PR TITLE
ro: Implement ro:1, add ldrRoLoadNrrEx, fix roDmnt

### DIFF
--- a/nx/include/switch/services/ldr.h
+++ b/nx/include/switch/services/ldr.h
@@ -42,7 +42,7 @@ Result ldrShellClearLaunchQueue(void);
 
 Result ldrDmntAddTitleToLaunchQueue(u64 tid, const void *args, size_t args_size);
 Result ldrDmntClearLaunchQueue(void);
-Result ldrDmntGetModuleInfos(u64 pid, LoaderModuleInfo *out_module_infos, size_t out_size, u32 *num_out);
+Result ldrDmntGetModuleInfos(u64 pid, LoaderModuleInfo *out_module_infos, size_t max_out_modules, u32 *num_out);
 
 Result ldrPmCreateProcess(u64 flags, u64 launch_index, Handle reslimit_h, Handle *out_process_h);
 Result ldrPmGetProgramInfo(u64 title_id, FsStorageId storage_id, LoaderProgramInfo *out_program_info);

--- a/nx/include/switch/services/ro.h
+++ b/nx/include/switch/services/ro.h
@@ -19,5 +19,6 @@ Result ldrRoLoadNro(u64* out_address, u64 nro_address, u64 nro_size, u64 bss_add
 Result ldrRoUnloadNro(u64 nro_address);
 Result ldrRoLoadNrr(u64 nrr_address, u64 nrr_size);
 Result ldrRoUnloadNrr(u64 nrr_address);
+Result ldrRoLoadNrrEx(u64 nrr_address, u64 nrr_size);
 
-Result roDmntGetModuleInfos(u64 pid, LoaderModuleInfo *out_module_infos, size_t out_size, u32 *num_out);
+Result roDmntGetModuleInfos(u64 pid, LoaderModuleInfo *out_module_infos, size_t max_out_modules, u32 *num_out);

--- a/nx/include/switch/services/ro.h
+++ b/nx/include/switch/services/ro.h
@@ -12,6 +12,9 @@
 Result ldrRoInitialize(void);
 void ldrRoExit(void);
 
+Result ro1Initialize(void);
+void ro1Exit(void);
+
 Result roDmntInitialize(void);
 void roDmntExit(void);
 
@@ -20,5 +23,11 @@ Result ldrRoUnloadNro(u64 nro_address);
 Result ldrRoLoadNrr(u64 nrr_address, u64 nrr_size);
 Result ldrRoUnloadNrr(u64 nrr_address);
 Result ldrRoLoadNrrEx(u64 nrr_address, u64 nrr_size);
+
+Result ro1LoadNro(u64* out_address, u64 nro_address, u64 nro_size, u64 bss_address, u64 bss_size);
+Result ro1UnloadNro(u64 nro_address);
+Result ro1LoadNrr(u64 nrr_address, u64 nrr_size);
+Result ro1UnloadNrr(u64 nrr_address);
+Result ro1LoadNrrEx(u64 nrr_address, u64 nrr_size);
 
 Result roDmntGetModuleInfos(u64 pid, LoaderModuleInfo *out_module_infos, size_t max_out_modules, u32 *num_out);

--- a/nx/source/services/ldr.c
+++ b/nx/source/services/ldr.c
@@ -132,11 +132,11 @@ Result ldrDmntClearLaunchQueue(void) {
     return _ldrClearLaunchQueue(&g_dmntSrv);
 }
 
-Result ldrDmntGetModuleInfos(u64 pid, LoaderModuleInfo *out_module_infos, size_t out_size, u32 *num_out) {
+Result ldrDmntGetModuleInfos(u64 pid, LoaderModuleInfo *out_module_infos, size_t max_out_modules, u32 *num_out) {
     IpcCommand c;
     ipcInitialize(&c);
     
-    ipcAddRecvStatic(&c, out_module_infos, out_size, 0);
+    ipcAddRecvStatic(&c, out_module_infos, max_out_modules * sizeof(*out_module_infos), 0);
 
     struct {
         u64 magic;


### PR DESCRIPTION
This updates ro services to the modern day.

Adds ro:1 (and new ldrRoLoadNrrEx command added in 7.0.0)

Also fixes roDmnt sending the wrong kind of IPC buffer.