### PR TITLE
spl: fix BootReason command names

### DIFF
--- a/nx/include/switch/services/spl.h
+++ b/nx/include/switch/services/spl.h
@@ -57,8 +57,8 @@ Result splUserExpMod(const void *input, const void *modulus, const void *exp, si
 Result splSetConfig(SplConfigItem config_item, u64 value);
 Result splGetRandomBytes(void *out, size_t out_size);
 Result splIsDevelopment(bool *out_is_development);
-Result splSetSharedData(u32 value);
-Result splGetSharedData(u32 *out_value);
+Result splSetBootReason(u32 value);
+Result splGetBootReason(u32 *out_value);
 
 Result splCryptoGenerateAesKek(const void *wrapped_kek, u32 key_generation, u32 option, void *out_sealed_kek);
 Result splCryptoLoadAesKey(const void *sealed_kek, const void *wrapped_key, u32 keyslot);

--- a/nx/source/services/spl.c
+++ b/nx/source/services/spl.c
@@ -344,7 +344,11 @@ Result splIsDevelopment(bool *out_is_development) {
     return rc;
 }
 
-Result splSetSharedData(u32 value) {
+Result splSetBootReason(u32 value) {
+    if (hosversionBefore(3,0,0)) {
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+    }
+
     IpcCommand c;
     ipcInitialize(&c);
 
@@ -377,7 +381,11 @@ Result splSetSharedData(u32 value) {
     return rc;
 }
 
-Result splGetSharedData(u32 *out_value) {
+Result splGetBootReason(u32 *out_value) {
+    if (hosversionBefore(3,0,0)) {
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+    }
+
     IpcCommand c;
     ipcInitialize(&c);
 


### PR DESCRIPTION
Also checks HosVersionBefore(3, 0, 0) before calling them.