### PR TITLE
fsdev: add way of getting last returned result.

### DIFF
--- a/nx/include/switch/runtime/devices/fs_dev.h
+++ b/nx/include/switch/runtime/devices/fs_dev.h
@@ -53,3 +53,6 @@ Result fsdevDeleteDirectoryRecursively(const char *path);
 
 /// Unmounts all devices and cleans up any resources used by the FS driver.
 Result fsdevUnmountAll(void);
+
+/// Gets the last error returned by fsdev.
+Result fsdevGetLastResult(void);

--- a/nx/include/switch/runtime/devices/fs_dev.h
+++ b/nx/include/switch/runtime/devices/fs_dev.h
@@ -54,5 +54,5 @@ Result fsdevDeleteDirectoryRecursively(const char *path);
 /// Unmounts all devices and cleans up any resources used by the FS driver.
 Result fsdevUnmountAll(void);
 
-/// Gets the last error returned by fsdev.
+/// Retrieves the last native result code generated during a failed fsdev operation.
 Result fsdevGetLastResult(void);

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -101,6 +101,7 @@ typedef struct
 static bool fsdev_initialised = false;
 static s32 fsdev_fsdevice_default = -1;
 static s32 fsdev_fsdevice_cwd = -1;
+static __thread Result fsdev_last_result = 0;
 static fsdev_fsdevice fsdev_fsdevices[32];
 
 /*! @endcond */
@@ -1647,6 +1648,7 @@ error_cmp(const void *p1, const void *p2)
 static int
 fsdev_translate_error(Result error)
 {
+  fsdev_last_result = error;
   error_map_t key = { .fs_error = error };
   const error_map_t *rc = bsearch(&key, error_table, num_errors,
                                   sizeof(error_map_t), error_cmp);
@@ -1654,6 +1656,14 @@ fsdev_translate_error(Result error)
   if(rc != NULL)
     return rc->error;
 
-  return (int)error;
+  return EIO;
+}
+
+/*! Getter for last error code translated to errno by fsdev library.
+ *
+ *  @returns result
+ */
+Result fsdevGetLastResult(void) {
+    return fsdev_last_result;
 }
 


### PR DESCRIPTION
Adds fsdevGetLastResult, which returns a thread local Result updated by every call to fsdev_translate_error.

Also changes fsdev_translate_error to return EIO instead of raw results, when not translatable.