### PR TITLE
romfs_dev: fix unmounting/corruption when mounting multiple.

### DIFF
--- a/nx/source/runtime/devices/romfs_dev.c
+++ b/nx/source/runtime/devices/romfs_dev.c
@@ -392,6 +392,7 @@ Result romfsMountCommon(const char *name, romfs_mount *mount)
     if(AddDevice(&mount->device) < 0)
         goto fail;
 
+    mount->setup = true;
     return 0;
 
 fail:


### PR DESCRIPTION
->setup was never being written.