### PR TITLE
fs: fix file/storage API, add fsdevCreateFile, add fsOpenFileSystemWithPatch.

### DIFF
--- a/nx/include/switch/runtime/devices/fs_dev.h
+++ b/nx/include/switch/runtime/devices/fs_dev.h
@@ -48,6 +48,9 @@ int fsdevTranslatePath(const char *path, FsFileSystem** device, char *outpath);
 /// This calls fsFsSetArchiveBit on the filesystem specified by the input path (as used in stdio).
 Result fsdevSetArchiveBit(const char *path);
 
+/// This calls fsFsCreateFile on the filesystem specified by the input path (as used in stdio).
+Result fsdevCreateFile(const char* path, size_t size, int flags);
+
 /// Recursively deletes the directory specified by the input path (as used in stdio).
 Result fsdevDeleteDirectoryRecursively(const char *path);
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -98,8 +98,8 @@ typedef struct
 } FsTimeStampRaw;
 
 typedef enum {
-    ENTRYTYPE_DIR = 0,
-    ENTRYTYPE_FILE = 1
+    ENTRYTYPE_DIR  = 0,
+    ENTRYTYPE_FILE = 1,
 } FsEntryType;
 
 typedef enum
@@ -129,15 +129,15 @@ typedef enum
 
 typedef enum
 {
-    FS_WRITEOPTION_NONE = 0,       ///< No option.
+    FS_WRITEOPTION_NONE  = 0,      ///< No option.
     FS_WRITEOPTION_FLUSH = BIT(0), ///< Forces a flush after write.
 } FsWriteOption;
 
 typedef enum
 {
-    FsStorageId_None =       0,
-    FsStorageId_Host =       1,
-    FsStorageId_GameCard =   2,
+    FsStorageId_None       = 0,
+    FsStorageId_Host       = 1,
+    FsStorageId_GameCard   = 2,
     FsStorageId_NandSystem = 3,
     FsStorageId_NandUser   = 4,
     FsStorageId_SdCard     = 5,
@@ -157,7 +157,7 @@ typedef enum
     FsSaveDataSpaceId_SdCard           = 2,
     FsSaveDataSpaceId_TemporaryStorage = 3,
 
-    FsSaveDataSpaceId_All = -1,             ///< Pseudo value for fsOpenSaveDataIterator().
+    FsSaveDataSpaceId_All              = -1, ///< Pseudo value for fsOpenSaveDataIterator().
 } FsSaveDataSpaceId;
 
 typedef enum
@@ -181,7 +181,7 @@ typedef struct {
 } FsGameCardHandle;
 
 typedef struct {
-    u32 aes_ctr_key_type;           ///< Contains bitflags describing how data is AES encrypted
+    u32 aes_ctr_key_type;           ///< Contains bitflags describing how data is AES encrypted.
     u32 speed_emulation_type;       ///< Contains bitflags describing how data is emulated.
     u32 reserved[0x38/sizeof(u32)];
 } FsRangeInfo;
@@ -227,12 +227,12 @@ Result fsMount_SystemSaveData(FsFileSystem* out, u64 saveID);
 
 typedef enum
 {
-    FsFileSystemType_Logo = 2,
-    FsFileSystemType_ContentControl = 3,
-    FsFileSystemType_ContentManual = 4,
-    FsFileSystemType_ContentMeta = 5,
-    FsFileSystemType_ContentData = 6,
-    FsFileSystemType_ApplicationPackage = 7
+    FsFileSystemType_Logo               = 2,
+    FsFileSystemType_ContentControl     = 3,
+    FsFileSystemType_ContentManual      = 4,
+    FsFileSystemType_ContentMeta        = 5,
+    FsFileSystemType_ContentData        = 6,
+    FsFileSystemType_ApplicationPackage = 7,
 } FsFileSystemType;
 
 typedef enum

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -193,13 +193,34 @@ typedef enum {
     FsOperationId_QueryRange,      ///< Retrieves information on data for supported file/storage.
 } FsOperationId;
 
+typedef enum {
+    FsBisStorageId_Boot0                           = 0,
+
+    FsBisStorageId_Boot1                           = 10,
+
+    FsBisStorageId_UserDataRoot                    = 20,
+    FsBisStorageId_BootConfigAndPackage2NormalMain = 21,
+    FsBisStorageId_BootConfigAndPackage2NormalSub  = 22,
+    FsBisStorageId_BootConfigAndPackage2SafeMain   = 23,
+    FsBisStorageId_BootConfigAndPackage2SafeSub    = 24,
+    FsBisStorageId_BootConfigAndPackage2RepairMain = 25,
+    FsBisStorageId_BootConfigAndPackage2RepairSub  = 26,
+    FsBisStorageId_CalibrationBinary               = 27,
+    FsBisStorageId_CalibrationFile                 = 28,
+    FsBisStorageId_SafeMode                        = 29,
+    FsBisStorageId_User                            = 30,
+    FsBisStorageId_System                          = 31,
+    FsBisStorageId_SystemProperEncryption          = 32,
+    FsBisStorageId_SystemProperPartition           = 33,
+} FsBisStorageId;
+
 Result fsInitialize(void);
 void fsExit(void);
 
 Service* fsGetServiceSession(void);
 
-Result fsOpenBisStorage(FsStorage* out, u32 PartitionId);
-Result fsOpenBisFileSystem(FsFileSystem* out, u32 PartitionId, const char* string);
+Result fsOpenBisStorage(FsStorage* out, FsBisStorageId PartitionId);
+Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId PartitionId, const char* string);
 
 Result fsIsExFatSupported(bool* out);
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -117,8 +117,8 @@ typedef enum
 /// For use with fsFsOpenDirectory.
 typedef enum
 {
-    FS_DIROPEN_DIRECTORY   = BIT(0),   ///< Enable reading directory entries.
-    FS_DIROPEN_FILE  = BIT(1),         ///< Enable reading file entries.
+    FS_DIROPEN_DIRECTORY    = BIT(0),  ///< Enable reading directory entries.
+    FS_DIROPEN_FILE         = BIT(1),  ///< Enable reading file entries.
     FS_DIROPEN_NO_FILE_SIZE = BIT(31), ///< Causes result entries to not contain filesize information (always 0).
 } FsDirectoryFlags;
 
@@ -274,7 +274,7 @@ Result fsFileWrite(FsFile* f, u64 off, const void* buf, size_t len, u32 option);
 Result fsFileFlush(FsFile* f);
 Result fsFileSetSize(FsFile* f, u64 sz);
 Result fsFileGetSize(FsFile* f, u64* out);
-Result fsFileOperateRange(FsFile* f, FsOperationId op_id, u64 off, size_t len, FsRangeInfo* out);
+Result fsFileOperateRange(FsFile* f, FsOperationId op_id, u64 off, size_t len, FsRangeInfo* out); /// 4.0.0+
 void fsFileClose(FsFile* f);
 
 // IDirectory
@@ -288,7 +288,7 @@ Result fsStorageWrite(FsStorage* s, u64 off, const void* buf, size_t len);
 Result fsStorageFlush(FsStorage* s);
 Result fsStorageSetSize(FsStorage* s, u64 sz);
 Result fsStorageGetSize(FsStorage* s, u64* out);
-Result fsStorageOperateRange(FsStorage* s, FsOperationId op_id, u64 off, size_t len, FsRangeInfo* out);
+Result fsStorageOperateRange(FsStorage* s, FsOperationId op_id, u64 off, size_t len, FsRangeInfo* out); /// 4.0.0+
 void fsStorageClose(FsStorage* s);
 
 // ISaveDataInfoReader

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -381,6 +381,16 @@ Result fsdevSetArchiveBit(const char *path) {
   return fsFsSetArchiveBit(&device->fs, fs_path);
 }
 
+Result fsdevCreateFile(const char* path, size_t size, int flags) {
+  char          fs_path[FS_MAX_PATH];
+  fsdev_fsdevice *device = NULL;
+
+  if(fsdev_getfspath(_REENT, path, &device, fs_path)==-1)
+    return MAKERESULT(Module_Libnx, LibnxError_NotFound);
+
+  return fsFsCreateFile(&device->fs, fs_path, size, flags);
+}
+
 Result fsdevDeleteDirectoryRecursively(const char *path) {
   char          fs_path[FS_MAX_PATH];
   fsdev_fsdevice *device = NULL;
@@ -680,7 +690,7 @@ fsdev_write(struct _reent *r,
     }
   }
 
-  rc = fsFileWrite(&file->fd, file->offset, ptr, len);
+  rc = fsFileWrite(&file->fd, file->offset, ptr, len, FS_WRITEOPTION_NONE);
   if(rc == 0xD401)
     return fsdev_write_safe(r, fd, ptr, len);
   if(R_FAILED(rc))
@@ -734,7 +744,7 @@ fsdev_write_safe(struct _reent *r,
     memcpy(tmp_buffer, ptr, toWrite);
 
     /* write the data */
-    rc = fsFileWrite(&file->fd, file->offset, tmp_buffer, toWrite);
+    rc = fsFileWrite(&file->fd, file->offset, tmp_buffer, toWrite, FS_WRITEOPTION_NONE);
 
     if(R_FAILED(rc))
     {
@@ -789,7 +799,7 @@ fsdev_read(struct _reent *r,
   }
 
   /* read the data */
-  rc = fsFileRead(&file->fd, file->offset, ptr, len, &bytes);
+  rc = fsFileRead(&file->fd, file->offset, ptr, len, FS_READOPTION_NONE, &bytes);
   if(rc == 0xD401)
     return fsdev_read_safe(r, fd, ptr, len);
   if(R_SUCCEEDED(rc))
@@ -836,7 +846,7 @@ fsdev_read_safe(struct _reent *r,
       toRead = sizeof(tmp_buffer);
 
     /* read the data */
-    rc = fsFileRead(&file->fd, file->offset, tmp_buffer, toRead, &bytes);
+    rc = fsFileRead(&file->fd, file->offset, tmp_buffer, toRead, FS_READOPTION_NONE, &bytes);
 
     if(bytes > toRead)
       bytes = toRead;

--- a/nx/source/runtime/devices/romfs_dev.c
+++ b/nx/source/runtime/devices/romfs_dev.c
@@ -56,7 +56,7 @@ static ssize_t _romfs_read(romfs_mount *mount, u64 offset, void* buffer, u64 siz
     Result rc = 0;
     if(mount->fd_type == RomfsSource_FsFile)
     {
-        rc = fsFileRead(&mount->fd, pos, buffer, size, &read);
+        rc = fsFileRead(&mount->fd, pos, buffer, size, FS_READOPTION_NONE, &read);
     }
     else if(mount->fd_type == RomfsSource_FsStorage)
     {

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -70,7 +70,7 @@ Service* fsGetServiceSession(void) {
     return &g_fsSrv;
 }
 
-Result fsOpenBisStorage(FsStorage* out, u32 PartitionId) {
+Result fsOpenBisStorage(FsStorage* out, FsBisStorageId PartitionId) {
     IpcCommand c;
     ipcInitialize(&c);
 
@@ -108,7 +108,7 @@ Result fsOpenBisStorage(FsStorage* out, u32 PartitionId) {
     return rc;
 }
 
-Result fsOpenBisFileSystem(FsFileSystem* out, u32 PartitionId, const char* string) {
+Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId PartitionId, const char* string) {
     IpcCommand c;
     ipcInitialize(&c);
 


### PR DESCRIPTION
Fixes API for fsFsCreateFile, fsFsReadFile, fsFsWriteFile.

Fixes missing flag for DIROPEN, adds missing flags for CREATE/READ/WRITE.

Adds missing *OperateRange commands.

Adds missing fsOpenFileSystemWithPatch command.

Adds fsdevCreateFile helper to create file with flags via stdio-paths.