### PR TITLE
Implement fsOpenContentStorageFileSystem, fsGetRightsIdByPath & fsGetRightsIdAndKeyGenerationByPath

### DIFF
--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -188,7 +188,11 @@ Result fsOpenDataStorageByCurrentProcess(FsStorage* out);
 Result fsOpenDataStorageByDataId(FsStorage* out, u64 dataId, FsStorageId storageId);
 Result fsOpenDeviceOperator(FsDeviceOperator* out);
 Result fsOpenSdCardDetectionEventNotifier(FsEventNotifier* out);
+
+// Retrieves the rights id corresponding to the content path. Only available on [2.0.0+].
 Result fsGetRightsIdByPath(const char* path, FsRightsId* out_rights_id);
+
+// Retrieves the rights id and key generation corresponding to the content path. Only available on [3.0.0+].
 Result fsGetRightsIdAndKeyGenerationByPath(const char* path, u8* out_key_generation, FsRightsId* out_rights_id);
 // todo: Rest of commands here
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -21,6 +21,10 @@
 #define FS_SAVEDATA_USERID_COMMONSAVE 0
 
 typedef struct {
+    u8 c[0x10];
+} FsRightsId;
+
+typedef struct {
     Service  s;
 } FsFileSystem;
 
@@ -179,10 +183,13 @@ Result fsMountSdcard(FsFileSystem* out);
 Result fsMountSaveData(FsFileSystem* out, u8 inval, FsSave *save);
 Result fsMountSystemSaveData(FsFileSystem* out, u8 inval, FsSave *save);
 Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId);
+Result fsOpenContentStorageFileSystem(FsFileSystem* out, FsContentStorageId content_storage_id);
 Result fsOpenDataStorageByCurrentProcess(FsStorage* out);
 Result fsOpenDataStorageByDataId(FsStorage* out, u64 dataId, FsStorageId storageId);
 Result fsOpenDeviceOperator(FsDeviceOperator* out);
 Result fsOpenSdCardDetectionEventNotifier(FsEventNotifier* out);
+Result fsGetRightsIdByPath(const char* path, FsRightsId* out_rights_id);
+Result fsGetRightsIdAndKeyGenerationByPath(const char* path, u8* out_key_generation, FsRightsId* out_rights_id);
 // todo: Rest of commands here
 
 /// FsFileSystem can be mounted with fs_dev for use with stdio, see fs_dev.h.

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -189,10 +189,10 @@ Result fsOpenDataStorageByDataId(FsStorage* out, u64 dataId, FsStorageId storage
 Result fsOpenDeviceOperator(FsDeviceOperator* out);
 Result fsOpenSdCardDetectionEventNotifier(FsEventNotifier* out);
 
-// Retrieves the rights id corresponding to the content path. Only available on [2.0.0+].
+/// Retrieves the rights id corresponding to the content path. Only available on [2.0.0+].
 Result fsGetRightsIdByPath(const char* path, FsRightsId* out_rights_id);
 
-// Retrieves the rights id and key generation corresponding to the content path. Only available on [3.0.0+].
+/// Retrieves the rights id and key generation corresponding to the content path. Only available on [3.0.0+].
 Result fsGetRightsIdAndKeyGenerationByPath(const char* path, u8* out_key_generation, FsRightsId* out_rights_id);
 // todo: Rest of commands here
 

--- a/nx/include/switch/services/ncm.h
+++ b/nx/include/switch/services/ncm.h
@@ -74,10 +74,6 @@ typedef struct {
     u64           baseTitleId;
 } NcmApplicationContentMetaKey;
 
-typedef struct {
-    u8 c[0x10];
-} NcmRightsId;
-
 Result ncmInitialize(void);
 void ncmExit(void);
 
@@ -97,7 +93,7 @@ Result ncmContentStorageCleanupAllPlaceHolder(NcmContentStorage* cs);
 Result ncmContentStorageGetSize(NcmContentStorage* cs, const NcmNcaId* ncaId, u64* out);
 Result ncmContentStorageDisableForcibly(NcmContentStorage* cs);
 Result ncmContentStorageReadContentIdFile(NcmContentStorage* cs, const NcmNcaId* ncaId, u64 offset, void* outBuf, size_t bufSize);
-Result ncmContentStorageGetRightsIdFromContentId(NcmContentStorage* cs, const NcmNcaId* ncaId, NcmRightsId* rightsIdOut, u32* keyGenerationOut);
+Result ncmContentStorageGetRightsIdFromContentId(NcmContentStorage* cs, const NcmNcaId* ncaId, FsRightsId* rightsIdOut, u32* keyGenerationOut);
 
 Result ncmContentMetaDatabaseSet(NcmContentMetaDatabase* db, const NcmMetaRecord* record, u64 inDataSize, const NcmContentMetaRecordsHeader* srcRecordsData);
 Result ncmContentMetaDatabaseGet(NcmContentMetaDatabase* db, const NcmMetaRecord* record, u64 outDataSize, NcmContentMetaRecordsHeader* outRecordsData, u64* sizeRead);

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -504,6 +504,9 @@ Result fsOpenSdCardDetectionEventNotifier(FsEventNotifier* out) {
 }
 
 Result fsGetRightsIdByPath(const char* path, FsRightsId* out_rights_id) {
+    if (hosversionBefore(2,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
     char send_path[FS_MAX_PATH] = {0};
     IpcCommand c;
     ipcInitialize(&c);
@@ -535,7 +538,7 @@ Result fsGetRightsIdByPath(const char* path, FsRightsId* out_rights_id) {
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            *out_rights_id = resp->rights_id;
+            if (out_rights_id) *out_rights_id = resp->rights_id;
         }
     }
 
@@ -543,6 +546,9 @@ Result fsGetRightsIdByPath(const char* path, FsRightsId* out_rights_id) {
 }
 
 Result fsGetRightsIdAndKeyGenerationByPath(const char* path, u8* out_key_generation, FsRightsId* out_rights_id) {
+    if (hosversionBefore(3,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+    
     char send_path[FS_MAX_PATH] = {0};
     IpcCommand c;
     ipcInitialize(&c);
@@ -576,8 +582,8 @@ Result fsGetRightsIdAndKeyGenerationByPath(const char* path, u8* out_key_generat
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            *out_key_generation = resp->key_generation;
-            *out_rights_id = resp->rights_id;
+            if (out_key_generation) *out_key_generation = resp->key_generation;
+            if (out_rights_id) *out_rights_id = resp->rights_id;
         }
     }
 

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -317,6 +317,44 @@ Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId) {
     return rc;
 }
 
+Result fsOpenContentStorageFileSystem(FsFileSystem* out, FsContentStorageId content_storage_id) {
+    IpcCommand c;
+    ipcInitialize(&c);
+
+    struct {
+        u64 magic;
+        u64 cmd_id;
+        u32 content_storage_id;
+    } *raw;
+
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
+
+    raw->magic = SFCI_MAGIC;
+    raw->cmd_id = 110;
+    raw->content_storage_id = content_storage_id;
+
+    Result rc = serviceIpcDispatch(&g_fsSrv);
+
+    if (R_SUCCEEDED(rc)) {
+        IpcParsedCommand r;
+        struct {
+            u64 magic;
+            u64 result;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
+
+        rc = resp->result;
+
+        if (R_SUCCEEDED(rc)) {
+            serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
+        }
+    }
+
+    return rc;
+}
+
 Result fsOpenDataStorageByCurrentProcess(FsStorage* out) {
     IpcCommand c;
     ipcInitialize(&c);
@@ -459,6 +497,87 @@ Result fsOpenSdCardDetectionEventNotifier(FsEventNotifier* out) {
 
         if (R_SUCCEEDED(rc)) {
             serviceCreateSubservice(&out->s, &g_fsSrv, &r, 0);
+        }
+    }
+
+    return rc;
+}
+
+Result fsGetRightsIdByPath(const char* path, FsRightsId* out_rights_id) {
+    char send_path[FS_MAX_PATH] = {0};
+    IpcCommand c;
+    ipcInitialize(&c);
+    ipcAddSendStatic(&c, send_path, FS_MAX_PATH, 0);
+
+    struct {
+        u64 magic;
+        u64 cmd_id;
+    } *raw;
+
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
+    raw->magic = SFCI_MAGIC;
+    raw->cmd_id = 609;
+
+    strncpy(send_path, path, FS_MAX_PATH-1);
+    Result rc = serviceIpcDispatch(&g_fsSrv);
+
+    if (R_SUCCEEDED(rc)) {
+        IpcParsedCommand r;
+        struct {
+            u64 magic;
+            u64 result;
+            FsRightsId rights_id;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
+
+        rc = resp->result;
+
+        if (R_SUCCEEDED(rc)) {
+            *out_rights_id = resp->rights_id;
+        }
+    }
+
+    return rc;
+}
+
+Result fsGetRightsIdAndKeyGenerationByPath(const char* path, u8* out_key_generation, FsRightsId* out_rights_id) {
+    char send_path[FS_MAX_PATH] = {0};
+    IpcCommand c;
+    ipcInitialize(&c);
+    ipcAddSendStatic(&c, send_path, FS_MAX_PATH, 0);
+
+    struct {
+        u64 magic;
+        u64 cmd_id;
+    } *raw;
+
+    raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
+    raw->magic = SFCI_MAGIC;
+    raw->cmd_id = 610;
+
+    strncpy(send_path, path, FS_MAX_PATH-1);
+    Result rc = serviceIpcDispatch(&g_fsSrv);
+
+    if (R_SUCCEEDED(rc)) {
+        IpcParsedCommand r;
+        struct {
+            u64 magic;
+            u64 result;
+            u8 key_generation;
+            u8 padding[0x7];
+            FsRightsId rights_id;
+        } *resp;
+
+        serviceIpcParse(&g_fsSrv, &r, sizeof(*resp));
+        resp = r.Raw;
+
+        rc = resp->result;
+
+        if (R_SUCCEEDED(rc)) {
+            *out_key_generation = resp->key_generation;
+            *out_rights_id = resp->rights_id;
         }
     }
 

--- a/nx/source/services/ncm.c
+++ b/nx/source/services/ncm.c
@@ -542,7 +542,7 @@ Result ncmContentStorageReadContentIdFile(NcmContentStorage* cs, const NcmNcaId*
     return rc;
 }
 
-Result ncmContentStorageGetRightsIdFromContentId(NcmContentStorage* cs, const NcmNcaId* ncaId, NcmRightsId* rightsIdOut, u32* keyGenerationOut) {
+Result ncmContentStorageGetRightsIdFromContentId(NcmContentStorage* cs, const NcmNcaId* ncaId, FsRightsId* rightsIdOut, u32* keyGenerationOut) {
     IpcCommand c;
     ipcInitialize(&c);
     
@@ -566,14 +566,14 @@ Result ncmContentStorageGetRightsIdFromContentId(NcmContentStorage* cs, const Nc
         struct {
             u64 magic;
             u64 result;
-            NcmRightsId rights_id;
+            FsRightsId rights_id;
             u32 key_generation;
         } *resp = r.Raw;
 
         rc = resp->result;
 
         if (R_SUCCEEDED(rc)) {
-            if (rightsIdOut) memcpy(rightsIdOut, &resp->rights_id, sizeof(NcmRightsId));
+            if (rightsIdOut) memcpy(rightsIdOut, &resp->rights_id, sizeof(FsRightsId));
             if (keyGenerationOut) *keyGenerationOut = resp->key_generation;
         }
     }


### PR DESCRIPTION
Required for NCM reimplementation. Please note that the RightsId struct had to be moved from the NCM header to the FS header as they both rely on it, and the NCM header already depends on the FS header. Leaving it as-is would lead to a circular dependency, plus I believe it's more suitable for the FS header anyway.