### PR TITLE
Implement setsys GetDeviceNickname/SetDeviceNickname

### DIFF
--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -184,6 +184,6 @@ Result setsysGetDeviceNickname(char* buffer);
 
 /**
  * @brief Sets the system's nickname.
- * @param buffer Pointer to read the nickname from. (The buffer size needs to be at least 0x80 bytes)
+ * @param buffer Pointer to read the nickname from.
  */
 Result setsysSetDeviceNickname(const char* buffer);

--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -186,4 +186,4 @@ Result setsysGetDeviceNickname(char* buffer);
  * @brief Sets the system's nickname.
  * @param buffer Pointer to read the nickname from. (The buffer size needs to be at least 0x80 bytes)
  */
-Result setsysSetDeviceNickname(char* buffer);
+Result setsysSetDeviceNickname(const char* buffer);

--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -11,6 +11,7 @@
 #include "../kernel/event.h"
 
 #define SET_MAX_NAME_SIZE 0x48
+#define SET_MAX_NICKNAME_SIZE 0x80
 
 typedef enum {
     ColorSetId_Light=0,
@@ -178,12 +179,12 @@ Result setsysGetFatalDirtyFlags(u64 *flags_0, u64 *flags_1);
 
 /**
  * @brief Gets the system's nickname.
- * @param buffer Pointer to output the nickname to. (The buffer size needs to be at least 0x80 bytes)
+ * @param nickname Pointer to output the nickname to. (The buffer size needs to be at least 0x80 bytes)
  */
-Result setsysGetDeviceNickname(char* buffer);
+Result setsysGetDeviceNickname(char* nickname);
 
 /**
  * @brief Sets the system's nickname.
- * @param buffer Pointer to read the nickname from.
+ * @param nickname Pointer to read the nickname from.
  */
-Result setsysSetDeviceNickname(const char* buffer);
+Result setsysSetDeviceNickname(const char* nickname);

--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -175,3 +175,15 @@ Result setsysBindFatalDirtyFlagEvent(Event *out);
  * @param flags_1 Pointer to populate with second 64 flags.
  */
 Result setsysGetFatalDirtyFlags(u64 *flags_0, u64 *flags_1);
+
+/**
+ * @brief Gets the system's nickname.
+ * @param buffer Pointer to output the nickname to. (The buffer size needs to be at least 0x80 bytes)
+ */
+Result setsysGetDeviceNickname(char* buffer);
+
+/**
+ * @brief Sets the system's nickname.
+ * @param buffer Pointer to read the nickname from.
+ */
+Result setsysSetDeviceNickname(char* buffer);

--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -184,6 +184,6 @@ Result setsysGetDeviceNickname(char* buffer);
 
 /**
  * @brief Sets the system's nickname.
- * @param buffer Pointer to read the nickname from.
+ * @param buffer Pointer to read the nickname from. (The buffer size needs to be at least 0x80 bytes)
  */
 Result setsysSetDeviceNickname(char* buffer);

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -721,8 +721,7 @@ Result setsysGetDeviceNickname(char* nickname) {
 }
 
 Result setsysSetDeviceNickname(const char* nickname) {
-    char send_nickname[SET_MAX_NICKNAME_SIZE];
-    memset(send_nickname, 0, SET_MAX_NICKNAME_SIZE);
+    char send_nickname[SET_MAX_NICKNAME_SIZE] = {0};
     strncpy(send_nickname, nickname, SET_MAX_NICKNAME_SIZE-1);
 
     IpcCommand c;

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -692,7 +692,7 @@ Result setsysGetDeviceNickname(char* buffer) {
     ipcInitialize(&c);
 
     ipcAddRecvBuffer(&c, buffer, 0x80, BufferType_Normal);
- 
+
     struct {
         u64 magic;
         u64 cmd_id;
@@ -702,7 +702,7 @@ Result setsysGetDeviceNickname(char* buffer) {
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 77;
-    
+
     Result rc = serviceIpcDispatch(&g_setsysSrv);
 
     if (R_SUCCEEDED(rc)) {

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -686,3 +686,69 @@ Result setsysGetFatalDirtyFlags(u64 *flags_0, u64 *flags_1) {
 
     return rc;
 }
+
+Result setsysGetDeviceNickname(char* buffer) {
+    IpcCommand c;
+    ipcInitialize(&c);
+
+    ipcAddRecvBuffer(&c, buffer, 0x80, BufferType_Normal);
+ 
+    struct {
+        u64 magic;
+        u64 cmd_id;
+    } *raw;
+
+    raw = ipcPrepareHeader(&c, sizeof(*raw));
+
+    raw->magic = SFCI_MAGIC;
+    raw->cmd_id = 77;
+    
+    Result rc = serviceIpcDispatch(&g_setsysSrv);
+
+    if (R_SUCCEEDED(rc)) {
+        IpcParsedCommand r;
+        ipcParse(&r);
+
+        struct {
+            u64 magic;
+            u64 result;
+        } *resp = r.Raw;
+
+        rc = resp->result;
+    }
+
+    return rc;
+}
+
+Result setsysSetDeviceNickname(char* buffer) {
+    IpcCommand c;
+    ipcInitialize(&c);
+
+    ipcAddSendBuffer(&c, buffer, 0x80, BufferType_Normal);
+
+    struct {
+        u64 magic;
+        u64 cmd_id;
+    } *raw;
+
+    raw = ipcPrepareHeader(&c, sizeof(*raw));
+
+    raw->magic = SFCI_MAGIC;
+    raw->cmd_id = 78;
+
+    Result rc = serviceIpcDispatch(&g_setsysSrv);
+
+    if (R_SUCCEEDED(rc)) {
+        IpcParsedCommand r;
+        ipcParse(&r);
+
+        struct {
+            u64 magic;
+            u64 result;
+        } *resp = r.Raw;
+
+        rc = resp->result;
+    }
+
+    return rc;
+}

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -720,7 +720,7 @@ Result setsysGetDeviceNickname(char* buffer) {
     return rc;
 }
 
-Result setsysSetDeviceNickname(char* buffer) {
+Result setsysSetDeviceNickname(const char* buffer) {
     IpcCommand c;
     ipcInitialize(&c);
 

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -724,7 +724,7 @@ Result setsysSetDeviceNickname(const char* buffer) {
     IpcCommand c;
     ipcInitialize(&c);
 
-    ipcAddSendBuffer(&c, buffer, 0x80, BufferType_Normal);
+    ipcAddSendBuffer(&c, buffer, strlen(buffer) + 1, BufferType_Normal);
 
     struct {
         u64 magic;

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -687,11 +687,11 @@ Result setsysGetFatalDirtyFlags(u64 *flags_0, u64 *flags_1) {
     return rc;
 }
 
-Result setsysGetDeviceNickname(char* buffer) {
+Result setsysGetDeviceNickname(char* nickname) {
     IpcCommand c;
     ipcInitialize(&c);
 
-    ipcAddRecvBuffer(&c, buffer, 0x80, BufferType_Normal);
+    ipcAddRecvBuffer(&c, nickname, SET_MAX_NICKNAME_SIZE, BufferType_Normal);
 
     struct {
         u64 magic;
@@ -720,11 +720,14 @@ Result setsysGetDeviceNickname(char* buffer) {
     return rc;
 }
 
-Result setsysSetDeviceNickname(const char* buffer) {
+Result setsysSetDeviceNickname(const char* nickname) {
+    char send_nickname[SET_MAX_NICKNAME_SIZE];
+    memset(send_nickname, 0, SET_MAX_NICKNAME_SIZE);
+    strncpy(send_nickname, nickname, SET_MAX_NICKNAME_SIZE-1);
+
     IpcCommand c;
     ipcInitialize(&c);
-
-    ipcAddSendBuffer(&c, buffer, strlen(buffer) + 1, BufferType_Normal);
+    ipcAddSendBuffer(&c, send_nickname, SET_MAX_NICKNAME_SIZE, 0);
 
     struct {
         u64 magic;


### PR DESCRIPTION
Implements nn::settings::ISystemSettingsServer commands 77 & 78.

https://reswitched.github.io/SwIPC/ifaces.html#nn::settings::ISystemSettingsServer(77)
https://reswitched.github.io/SwIPC/ifaces.html#nn::settings::ISystemSettingsServer(78)

Useful for apps that might want to display or set the console's nickname.