### PR TITLE
Remove RomFS devoptab device on unmount.

### DIFF
--- a/nx/source/runtime/devices/romfs_dev.c
+++ b/nx/source/runtime/devices/romfs_dev.c
@@ -423,6 +423,9 @@ Result romfsUnmount(const char *name)
     if (mount == NULL)
         return -1;
 
+    // Remove device
+    RemoveDevice(name);
+
     romfs_mountclose(mount);
 
     return 0;


### PR DESCRIPTION
Not sure if this was somehow intended, tbh.