### PR TITLE
stub <sys/utsname.h>

### DIFF
--- a/nx/external/bsd/include/sys/utsname.h
+++ b/nx/external/bsd/include/sys/utsname.h
@@ -1,0 +1,31 @@
+/*
+ * Technically compliant implementation based on POSIX specification
+ */
+#ifndef _SYS_UTSNAME_H_
+#define _SYS_UTSNAME_H_
+
+/*
+ * "The character arrays are of unspecified size" assume 63 + null byte
+ *
+ * Members are stored in the order specified in the POSIX description
+ */
+struct utsname {
+  char sysname[64];
+  char nodename[64];
+  char release[64];
+  char version[64];
+  char machine[64];
+};
+
+/*
+ * `uname` can be defined as a macro or a function, so inline is fair game.
+ * 
+ * -1 shall be returned on error.
+ * 
+ * Note: errno should be set, but the spec doesn't give a list of valid codes.
+ */
+static inline int uname(struct utsname *name) {
+  return -1;
+}
+
+#endif


### PR DESCRIPTION
POSIX Reference: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_utsname.h.html

Required entries:

- `struct utsname` with 5 required fields
- `int uname(struct utsname *);` which can be inline