### PR TITLE
sm/smm: Add GetServiceSession

### DIFF
--- a/nx/include/switch/services/sm.h
+++ b/nx/include/switch/services/sm.h
@@ -281,10 +281,16 @@ Result smUnregisterService(const char* name);
 bool   smHasInitialized(void);
 
 /**
+ * @brief Gets the Service session used to communicate with SM.
+ * @return Pointer to service session used to communicate with SM.
+ */
+Service *smGetServiceSession(void);
+
+/**
  * @brief Encodes a service name as a 64-bit integer.
  * @param[in] name Name of the service.
  * @return Encoded name.
- */ 
+ */
 u64    smEncodeName(const char* name);
 
 /**

--- a/nx/include/switch/services/smm.h
+++ b/nx/include/switch/services/smm.h
@@ -12,5 +12,7 @@
 Result smManagerInitialize(void);
 void smManagerExit(void);
 
+Service* smManagerGetServiceSession(void);
+
 Result smManagerRegisterProcess(u64 pid, const void *acid_sac, size_t acid_sac_size, const void *aci0_sac, size_t aci0_sac_size);
 Result smManagerUnregisterProcess(u64 pid);


### PR DESCRIPTION
Adds `Service*smGetServiceSession()` and `Service*smManagerGetServiceSession()`.

This exposes Services usable to talk to sm/sm:m the same way as other libnx services (fs, etc).

sm had to be refactored to use Service * instead of a raw handle to support this.

This is useful because it allows for extensions to use the Services without having to duplicate sessions/handles.