### PR TITLE
Implement fsCreateSaveDataFileSystemBySystemSaveDataId (and wrappers) + fsDisableAutoSaveDataCreation

### DIFF
--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -82,7 +82,7 @@ typedef struct {
     u64 size;           ///< Size of the save data.
     u64 journalSize;    ///< Journal size of the save data.
     u64 blockSize;      ///< Block size of the save data.
-    u64 ownerId;        ///< Id of the save data's owner.
+    u64 ownerId;        ///< Title Id of the owner of this save data. 0 for SystemSaveData.
     u32 flags;          ///< Save data flags.
     u8 SaveDataSpaceId; ///< See \ref FsSaveDataSpaceId.
     u8 unk;             ///< 0 for SystemSaveData.

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -77,6 +77,19 @@ typedef struct
     u64 unk_x38;                    ///< 0 for SystemSaveData/SaveData.
 } FsSave;
 
+/// SaveCreate Struct
+typedef struct
+{
+    u64 journalSize;
+    u64 flags;
+    u64 blockSize;
+    u64 size;
+    u32 unk_x20;
+    u8 SaveDataSpaceId;
+    u8 unk_x25;
+    u8 uninitialized[0x1A];
+} FsSaveCreate;
+
 typedef struct
 {
     u64 saveID_unk;
@@ -226,6 +239,8 @@ Service* fsGetServiceSession(void);
 Result fsOpenBisStorage(FsStorage* out, FsBisStorageId PartitionId);
 Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId PartitionId, const char* string);
 
+Result fsCreateSaveDataFileSystemBySystemSaveDataId(FsSave* save, FsSaveCreate* create);
+
 Result fsIsExFatSupported(bool* out);
 
 /// Do not call this directly, see fs_dev.h.
@@ -245,7 +260,13 @@ Result fsGetRightsIdByPath(const char* path, FsRightsId* out_rights_id);
 
 /// Retrieves the rights id and key generation corresponding to the content path. Only available on [3.0.0+].
 Result fsGetRightsIdAndKeyGenerationByPath(const char* path, u8* out_key_generation, FsRightsId* out_rights_id);
+
+Result fsDisableAutoSaveDataCreation(void);
 // todo: Rest of commands here
+
+// Wrapper(s) for fsCreateSaveDataFileSystemBySystemSaveDataId.
+Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId space_id, u64 save_data_id, u64 user_id, u64 owner_id, u64 size, u64 journal_size, u32 flags);
+Result fsCreate_SystemSaveData(FsSaveDataSpaceId space_id, u64 save_data_id, u64 size, u64 journal_size, u32 flags);
 
 /// FsFileSystem can be mounted with fs_dev for use with stdio, see fs_dev.h.
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -78,16 +78,15 @@ typedef struct
 } FsSave;
 
 /// SaveCreate Struct
-typedef struct
-{
-    u64 size;
-    u64 journalSize;
-    u64 blockSize;
-    u64 ownerId;
-    u32 flags;
-    u8 SaveDataSpaceId;
-    u8 unk_x25;
-    u8 padding[0x1A];
+typedef struct {
+    u64 size;           ///< Size of the save data.
+    u64 journalSize;    ///< Journal size of the save data.
+    u64 blockSize;      ///< Block size of the save data.
+    u64 ownerId;        ///< Id of the save data's owner.
+    u32 flags;          ///< Save data flags.
+    u8 SaveDataSpaceId; ///< See \ref FsSaveDataSpaceId.
+    u8 unk;             ///< 0 for SystemSaveData.
+    u8 padding[0x1A];   ///< Uninitialized for SystemSaveData.
 } FsSaveCreate;
 
 typedef struct
@@ -265,8 +264,8 @@ Result fsDisableAutoSaveDataCreation(void);
 // todo: Rest of commands here
 
 // Wrapper(s) for fsCreateSaveDataFileSystemBySystemSaveDataId.
-Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId space_id, u64 save_data_id, u64 user_id, u64 owner_id, u64 size, u64 journal_size, u32 flags);
-Result fsCreate_SystemSaveData(FsSaveDataSpaceId space_id, u64 save_data_id, u64 size, u64 journal_size, u32 flags);
+Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u128 userID, u64 ownerId, u64 size, u64 journalSize, u32 flags);
+Result fsCreate_SystemSaveData(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u64 size, u64 journalSize, u32 flags);
 
 /// FsFileSystem can be mounted with fs_dev for use with stdio, see fs_dev.h.
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -238,7 +238,7 @@ Service* fsGetServiceSession(void);
 Result fsOpenBisStorage(FsStorage* out, FsBisStorageId PartitionId);
 Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId PartitionId, const char* string);
 
-Result fsCreateSaveDataFileSystemBySystemSaveDataId(FsSave* save, FsSaveCreate* create);
+Result fsCreateSaveDataFileSystemBySystemSaveDataId(const FsSave* save, const FsSaveCreate* create);
 
 Result fsIsExFatSupported(bool* out);
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -68,7 +68,7 @@ typedef struct
     u64 titleID;                    ///< titleID of the savedata to access when accessing other titles' savedata via SaveData, otherwise FS_SAVEDATA_CURRENT_TITLEID.
     union { u128 userID; } PACKED;  ///< userID of the user-specific savedata to access, otherwise FS_SAVEDATA_USERID_COMMONSAVE. See account.h.
     u64 saveID;                     ///< saveID, 0 for SaveData.
-    u8 SaveDataType;                ///< See \ref FsSaveDataType.
+    u8 saveDataType;                ///< See \ref FsSaveDataType.
     u8 rank;                        ///< Save data 'rank' or 'precedence'. 0 if this save data is considered the primary save data. 1 if it's considered the secondary save data.
     u16 index;                      ///< Save data index.
     u32 pad_x24;                    ///< Padding.
@@ -84,7 +84,7 @@ typedef struct {
     u64 blockSize;      ///< Block size of the save data.
     u64 ownerId;        ///< Title id of the owner of this save data. 0 for SystemSaveData.
     u32 flags;          ///< Save data flags.
-    u8 SaveDataSpaceId; ///< See \ref FsSaveDataSpaceId.
+    u8 saveDataSpaceId; ///< See \ref FsSaveDataSpaceId.
     u8 unk;             ///< 0 for SystemSaveData.
     u8 padding[0x1A];   ///< Uninitialized for SystemSaveData.
 } FsSaveCreate;
@@ -92,8 +92,8 @@ typedef struct {
 typedef struct
 {
     u64 saveID_unk;
-    u8 SaveDataSpaceId; ///< See \ref FsSaveDataSpaceId.
-    u8 SaveDataType;    ///< See \ref FsSaveDataType.
+    u8 saveDataSpaceId; ///< See \ref FsSaveDataSpaceId.
+    u8 saveDataType;    ///< See \ref FsSaveDataType.
     u8 pad[6];          ///< Padding.
     u128 userID;        ///< See userID for \ref FsSave.
     u64 saveID;         ///< See saveID for \ref FsSave.
@@ -235,8 +235,8 @@ void fsExit(void);
 
 Service* fsGetServiceSession(void);
 
-Result fsOpenBisStorage(FsStorage* out, FsBisStorageId PartitionId);
-Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId PartitionId, const char* string);
+Result fsOpenBisStorage(FsStorage* out, FsBisStorageId partitionId);
+Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId partitionId, const char* string);
 
 Result fsCreateSaveDataFileSystemBySystemSaveDataId(const FsSave* save, const FsSaveCreate* create);
 
@@ -247,7 +247,7 @@ Result fsMountSdcard(FsFileSystem* out);
 
 Result fsMountSaveData(FsFileSystem* out, u8 inval, FsSave *save);
 Result fsMountSystemSaveData(FsFileSystem* out, u8 inval, FsSave *save);
-Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId);
+Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 saveDataSpaceId);
 Result fsOpenContentStorageFileSystem(FsFileSystem* out, FsContentStorageId content_storage_id);
 Result fsOpenDataStorageByCurrentProcess(FsStorage* out);
 Result fsOpenDataStorageByDataId(FsStorage* out, u64 dataId, FsStorageId storageId);
@@ -264,8 +264,8 @@ Result fsDisableAutoSaveDataCreation(void);
 // todo: Rest of commands here
 
 // Wrapper(s) for fsCreateSaveDataFileSystemBySystemSaveDataId.
-Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u128 userID, u64 ownerId, u64 size, u64 journalSize, u32 flags);
-Result fsCreate_SystemSaveData(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u64 size, u64 journalSize, u32 flags);
+Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId saveDataSpaceId, u64 saveID, u128 userID, u64 ownerId, u64 size, u64 journalSize, u32 flags);
+Result fsCreate_SystemSaveData(FsSaveDataSpaceId saveDataSpaceId, u64 saveID, u64 size, u64 journalSize, u32 flags);
 
 /// FsFileSystem can be mounted with fs_dev for use with stdio, see fs_dev.h.
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -80,14 +80,14 @@ typedef struct
 /// SaveCreate Struct
 typedef struct
 {
-    u64 journalSize;
-    u64 flags;
-    u64 blockSize;
     u64 size;
-    u32 unk_x20;
+    u64 journalSize;
+    u64 blockSize;
+    u64 ownerId;
+    u32 flags;
     u8 SaveDataSpaceId;
     u8 unk_x25;
-    u8 uninitialized[0x1A];
+    u8 padding[0x1A];
 } FsSaveCreate;
 
 typedef struct

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -82,7 +82,7 @@ typedef struct {
     u64 size;           ///< Size of the save data.
     u64 journalSize;    ///< Journal size of the save data.
     u64 blockSize;      ///< Block size of the save data.
-    u64 ownerId;        ///< Title Id of the owner of this save data. 0 for SystemSaveData.
+    u64 ownerId;        ///< Title id of the owner of this save data. 0 for SystemSaveData.
     u32 flags;          ///< Save data flags.
     u8 SaveDataSpaceId; ///< See \ref FsSaveDataSpaceId.
     u8 unk;             ///< 0 for SystemSaveData.

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -701,20 +701,20 @@ Result fsIsExFatSupported(bool* out)
 }
 
 // Wrapper(s) for fsCreateSaveDataFileSystemBySystemSaveDataId.
-Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId space_id, u64 save_data_id, u64 user_id, u64 owner_id, u64 size, u64 journal_size, u32 flags) {
+Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u128 userID, u64 ownerId, u64 size, u64 journalSize, u32 flags) {
     FsSave save;
     FsSaveCreate create;
 
     memset(&save, 0, sizeof(save));
-    save.userID = (u128)user_id | ((u128)owner_id << 64);
-    save.saveID = save_data_id;
+    save.userID = userID;
+    save.saveID = saveID;
     memset(&create, 0, sizeof(create));
     create.size = size;
-    create.journalSize = journal_size;
+    create.journalSize = journalSize;
     create.blockSize = 0x4000;
-    create.ownerId = owner_id; 
+    create.ownerId = ownerId; 
     create.flags = flags;
-    create.SaveDataSpaceId = space_id;
+    create.SaveDataSpaceId = SaveDataSpaceId;
 
     return fsCreateSaveDataFileSystemBySystemSaveDataId(&save, &create);
 }

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -709,11 +709,12 @@ Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId space_id, u64 save_dat
     save.userID = (u128)user_id | ((u128)owner_id << 64);
     save.saveID = save_data_id;
     memset(&create, 0, sizeof(create));
-    create.SaveDataSpaceId = space_id;
-    create.blockSize = 0x4000;
-    create.journalSize = journal_size;
-    create.flags = flags;
     create.size = size;
+    create.journalSize = journal_size;
+    create.blockSize = 0x4000;
+    create.ownerId = owner_id; 
+    create.flags = flags;
+    create.SaveDataSpaceId = space_id;
 
     return fsCreateSaveDataFileSystemBySystemSaveDataId(&save, &create);
 }

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -150,7 +150,7 @@ Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId PartitionId, const 
     return rc;
 }
 
-Result fsCreateSaveDataFileSystemBySystemSaveDataId(FsSave* save, FsSaveCreate* create) {
+Result fsCreateSaveDataFileSystemBySystemSaveDataId(const FsSave* save, const FsSaveCreate* create) {
     IpcCommand c;
     ipcInitialize(&c);
 
@@ -702,19 +702,18 @@ Result fsIsExFatSupported(bool* out)
 
 // Wrapper(s) for fsCreateSaveDataFileSystemBySystemSaveDataId.
 Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u128 userID, u64 ownerId, u64 size, u64 journalSize, u32 flags) {
-    FsSave save;
-    FsSaveCreate create;
-
-    memset(&save, 0, sizeof(save));
-    save.userID = userID;
-    save.saveID = saveID;
-    memset(&create, 0, sizeof(create));
-    create.size = size;
-    create.journalSize = journalSize;
-    create.blockSize = 0x4000;
-    create.ownerId = ownerId; 
-    create.flags = flags;
-    create.SaveDataSpaceId = SaveDataSpaceId;
+    FsSave save = {
+        .userID = userID,
+        .saveID = saveID,
+    };
+    FsSaveCreate create = {
+        .size = size,
+        .journalSize = journalSize,
+        .blockSize = 0x4000,
+        .ownerId = ownerId,
+        .flags = flags,
+        .SaveDataSpaceId = SaveDataSpaceId,
+    };
 
     return fsCreateSaveDataFileSystemBySystemSaveDataId(&save, &create);
 }

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -719,8 +719,8 @@ Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId SaveDataSpaceId, u64 s
     return fsCreateSaveDataFileSystemBySystemSaveDataId(&save, &create);
 }
 
-Result fsCreate_SystemSaveData(FsSaveDataSpaceId space_id, u64 save_data_id, u64 size, u64 journal_size, u32 flags) {
-    return fsCreate_SystemSaveDataWithOwner(space_id, save_data_id, 0, 0, size, journal_size, flags);
+Result fsCreate_SystemSaveData(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u64 size, u64 journalSize, u32 flags) {
+    return fsCreate_SystemSaveDataWithOwner(SaveDataSpaceId, saveID, 0, 0, size, journalSize, flags);
 }
 
 // Wrapper(s) for fsMountSaveData.

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -70,7 +70,7 @@ Service* fsGetServiceSession(void) {
     return &g_fsSrv;
 }
 
-Result fsOpenBisStorage(FsStorage* out, FsBisStorageId PartitionId) {
+Result fsOpenBisStorage(FsStorage* out, FsBisStorageId partitionId) {
     IpcCommand c;
     ipcInitialize(&c);
 
@@ -84,7 +84,7 @@ Result fsOpenBisStorage(FsStorage* out, FsBisStorageId PartitionId) {
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 12;
-    raw->PartitionId = PartitionId;
+    raw->PartitionId = partitionId;
 
     Result rc = serviceIpcDispatch(&g_fsSrv);
 
@@ -108,7 +108,7 @@ Result fsOpenBisStorage(FsStorage* out, FsBisStorageId PartitionId) {
     return rc;
 }
 
-Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId PartitionId, const char* string) {
+Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId partitionId, const char* string) {
     IpcCommand c;
     ipcInitialize(&c);
 
@@ -126,7 +126,7 @@ Result fsOpenBisFileSystem(FsFileSystem* out, FsBisStorageId PartitionId, const 
 
     raw->magic = SFCI_MAGIC;
     raw->cmd_id = 11;
-    raw->PartitionId = PartitionId;
+    raw->PartitionId = partitionId;
 
     Result rc = serviceIpcDispatch(&g_fsSrv);
 
@@ -302,7 +302,7 @@ Result fsMountSystemSaveData(FsFileSystem* out, u8 inval, FsSave *save) {
     return rc;
 }
 
-Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId) {
+Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 saveDataSpaceId) {
     IpcCommand c;
     ipcInitialize(&c);
 
@@ -314,10 +314,10 @@ Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId) {
     struct {
         u64 magic;
         u64 cmd_id;
-        u8 SaveDataSpaceId;
+        u8 saveDataSpaceId;
     } *raw2;
 
-    if (SaveDataSpaceId == FsSaveDataSpaceId_All) {
+    if (saveDataSpaceId == FsSaveDataSpaceId_All) {
         raw = serviceIpcPrepareHeader(&g_fsSrv, &c, sizeof(*raw));
 
         raw->magic = SFCI_MAGIC;
@@ -328,7 +328,7 @@ Result fsOpenSaveDataIterator(FsSaveDataIterator* out, s32 SaveDataSpaceId) {
 
         raw2->magic = SFCI_MAGIC;
         raw2->cmd_id = 61;
-        raw2->SaveDataSpaceId = SaveDataSpaceId;
+        raw2->saveDataSpaceId = saveDataSpaceId;
     }
 
     Result rc = serviceIpcDispatch(&g_fsSrv);
@@ -701,7 +701,7 @@ Result fsIsExFatSupported(bool* out)
 }
 
 // Wrapper(s) for fsCreateSaveDataFileSystemBySystemSaveDataId.
-Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u128 userID, u64 ownerId, u64 size, u64 journalSize, u32 flags) {
+Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId saveDataSpaceId, u64 saveID, u128 userID, u64 ownerId, u64 size, u64 journalSize, u32 flags) {
     FsSave save = {
         .userID = userID,
         .saveID = saveID,
@@ -712,14 +712,14 @@ Result fsCreate_SystemSaveDataWithOwner(FsSaveDataSpaceId SaveDataSpaceId, u64 s
         .blockSize = 0x4000,
         .ownerId = ownerId,
         .flags = flags,
-        .SaveDataSpaceId = SaveDataSpaceId,
+        .saveDataSpaceId = saveDataSpaceId,
     };
 
     return fsCreateSaveDataFileSystemBySystemSaveDataId(&save, &create);
 }
 
-Result fsCreate_SystemSaveData(FsSaveDataSpaceId SaveDataSpaceId, u64 saveID, u64 size, u64 journalSize, u32 flags) {
-    return fsCreate_SystemSaveDataWithOwner(SaveDataSpaceId, saveID, 0, 0, size, journalSize, flags);
+Result fsCreate_SystemSaveData(FsSaveDataSpaceId saveDataSpaceId, u64 saveID, u64 size, u64 journalSize, u32 flags) {
+    return fsCreate_SystemSaveDataWithOwner(saveDataSpaceId, saveID, 0, 0, size, journalSize, flags);
 }
 
 // Wrapper(s) for fsMountSaveData.
@@ -729,7 +729,7 @@ Result fsMount_SaveData(FsFileSystem* out, u64 titleID, u128 userID) {
     memset(&save, 0, sizeof(save));
     save.titleID = titleID;
     save.userID = userID;
-    save.SaveDataType = FsSaveDataType_SaveData;
+    save.saveDataType = FsSaveDataType_SaveData;
 
     return fsMountSaveData(out, FsSaveDataSpaceId_NandUser, &save);
 }
@@ -739,7 +739,7 @@ Result fsMount_SystemSaveData(FsFileSystem* out, u64 saveID) {
 
     memset(&save, 0, sizeof(save));
     save.saveID = saveID;
-    save.SaveDataType = FsSaveDataType_SystemSaveData;
+    save.saveDataType = FsSaveDataType_SystemSaveData;
 
     return fsMountSystemSaveData(out, FsSaveDataSpaceId_NandSystem, &save);
 }


### PR DESCRIPTION
As per title. Needed for reimplementing any sysmodule with savedata.