### PR TITLE
Add a bunch of GetServiceSession functions

### DIFF
--- a/nx/include/switch/services/acc.h
+++ b/nx/include/switch/services/acc.h
@@ -33,7 +33,7 @@ typedef struct
 
 Result accountInitialize(void);
 void accountExit(void);
-Service* accountGetService(void);
+Service* accountGetServiceSession(void);
 
 /// Get the total number of user profiles
 Result accountGetUserCount(s32* user_count);

--- a/nx/include/switch/services/apm.h
+++ b/nx/include/switch/services/apm.h
@@ -6,6 +6,7 @@
  */
 #pragma once
 #include "../types.h"
+#include "../services/sm.h"
 
 /// CpuBoostMode. With \ref appletSetCpuBoostMode, only values 0/1 are available. This allows using higher clock rates.
 typedef enum {
@@ -16,6 +17,7 @@ typedef enum {
 
 Result apmInitialize(void);
 void apmExit(void);
+Service* apmGetServiceSession(void);
 
 Result apmSetPerformanceConfiguration(u32 PerformanceMode, u32 PerformanceConfiguration);
 Result apmGetPerformanceConfiguration(u32 PerformanceMode, u32 *PerformanceConfiguration);

--- a/nx/include/switch/services/auddev.h
+++ b/nx/include/switch/services/auddev.h
@@ -11,7 +11,7 @@
 
 Result auddevInitialize(void);
 void auddevExit(void);
-Service* auddevgetServiceSession(void);
+Service* auddevGetServiceSession(void);
 
 Result auddevListAudioDeviceName(AudioDeviceName *DeviceNames, s32 max_names, s32 *total_names);
 Result auddevSetAudioDeviceOutputVolume(const AudioDeviceName *DeviceName, float volume);

--- a/nx/include/switch/services/auddev.h
+++ b/nx/include/switch/services/auddev.h
@@ -7,9 +7,11 @@
 #pragma once
 
 #include "../audio/audio.h"
+#include "../services/sm.h"
 
 Result auddevInitialize(void);
 void auddevExit(void);
+Service* auddevgetServiceSession(void);
 
 Result auddevListAudioDeviceName(AudioDeviceName *DeviceNames, s32 max_names, s32 *total_names);
 Result auddevSetAudioDeviceOutputVolume(const AudioDeviceName *DeviceName, float volume);

--- a/nx/include/switch/services/audren.h
+++ b/nx/include/switch/services/audren.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../audio/audio.h"
+#include "../services/sm.h"
 
 #if __cplusplus >= 201402L
 #define AUDREN_CONSTEXPR constexpr
@@ -321,6 +322,7 @@ AUDREN_CONSTEXPR size_t audrenGetOutputParamSize(const AudioRendererConfig* conf
 
 Result audrenInitialize(const AudioRendererConfig* config);
 void audrenExit(void);
+Service* audrenGetServiceSession(void);
 void audrenWaitFrame(void);
 Result audrenGetState(u32* out_state);
 Result audrenRequestUpdateAudioRenderer(const void* in_param_buf, size_t in_param_buf_size, void* out_param_buf, size_t out_param_buf_size, void* perf_buf, size_t perf_buf_size);

--- a/nx/include/switch/services/bpc.h
+++ b/nx/include/switch/services/bpc.h
@@ -6,6 +6,7 @@
  */
 #pragma once
 #include "../types.h"
+#include "../services/sm.h"
 
 typedef enum {
     BpcSleepButtonState_Held = 0,
@@ -14,6 +15,7 @@ typedef enum {
 
 Result bpcInitialize(void);
 void bpcExit(void);
+Service* bpcGetServiceSession(void);
 
 Result bpcShutdownSystem(void);
 Result bpcRebootSystem(void);

--- a/nx/include/switch/services/bsd.h
+++ b/nx/include/switch/services/bsd.h
@@ -12,6 +12,7 @@
 
 #include "../types.h"
 #include "../kernel/tmem.h"
+#include "../services/sm.h"
 
 /// Configuration structure for bsdInitalize
 typedef struct  {
@@ -37,6 +38,7 @@ const BsdInitConfig *bsdGetDefaultInitConfig(void);
 Result bsdInitialize(const BsdInitConfig *config);
 /// Deinitialize the BSD service.
 void bsdExit(void);
+Service* bsdGetServiceSession(void);
 
 /// Creates a socket.
 int bsdSocket(int domain, int type, int protocol);

--- a/nx/include/switch/services/capssc.h
+++ b/nx/include/switch/services/capssc.h
@@ -12,6 +12,7 @@
 /// Initialize caps:sc. Only available on 2.0.0+.
 Result capsscInitialize(void);
 void capsscExit(void);
+Service* capsscGetServiceSession(void);
 
 /**
  * @brief This takes a screenshot, with the screenshot being written into the output buffer.

--- a/nx/include/switch/services/capssu.h
+++ b/nx/include/switch/services/capssu.h
@@ -12,6 +12,7 @@
 /// Initialize caps:su. Only available on 4.0.0+.
 Result capssuInitialize(void);
 void capssuExit(void);
+Service* capssuGetServiceSession(void);
 
 /// Same as \ref capssuSaveScreenShotEx0, except this uses an all-zero CapsScreenShotAttribute where the first u32 is set to attr_val. attr_val can be zero.
 Result capssuSaveScreenShot(const void* buffer, size_t size, u32 unk, u32 attr_val, CapsApplicationAlbumEntry *out);

--- a/nx/include/switch/services/clkrst.h
+++ b/nx/include/switch/services/clkrst.h
@@ -15,6 +15,7 @@ typedef struct {
 
 Result clkrstInitialize(void);
 void clkrstExit(void);
+Service* clkrstGetServiceSession(void);
 
 /// Opens a ClkrstSession for the requested PcvModuleId, unk is set to 3 in official sysmodules.
 Result clkrstOpenSession(ClkrstSession* session_out, PcvModuleId module_id, u32 unk);

--- a/nx/include/switch/services/csrng.h
+++ b/nx/include/switch/services/csrng.h
@@ -6,8 +6,10 @@
  */
 #pragma once
 #include "../types.h"
+#include "../services/sm.h"
 
 Result csrngInitialize(void);
 void csrngExit(void);
+Service* csrngGetServiceSession(void);
 
 Result csrngGetRandomBytes(void *out, size_t out_size);

--- a/nx/include/switch/services/fsldr.h
+++ b/nx/include/switch/services/fsldr.h
@@ -11,6 +11,7 @@
 
 Result fsldrInitialize(void);
 void fsldrExit(void);
+Service* fsldrGetServiceSession(void);
 
 Result fsldrOpenCodeFileSystem(u64 tid, const char *path, FsFileSystem* out);
 Result fsldrIsArchivedProgram(u64 pid, bool *out);

--- a/nx/include/switch/services/fspr.h
+++ b/nx/include/switch/services/fspr.h
@@ -11,6 +11,7 @@
 
 Result fsprInitialize(void);
 void fsprExit(void);
+Service* fsprGetServiceSession(void);
 
 Result fsprRegisterProgram(u64 pid, u64 titleID, FsStorageId storageID, const void *fs_access_header, size_t fah_size, const void *fs_access_control, size_t fac_size);
 Result fsprUnregisterProgram(u64 pid);

--- a/nx/include/switch/services/gpio.h
+++ b/nx/include/switch/services/gpio.h
@@ -30,6 +30,7 @@ typedef enum {
 
 Result gpioInitialize(void);
 void gpioExit(void);
+Service* gpioGetServiceSession(void);
 
 Result gpioOpenSession(GpioPadSession *out, GpioPadName name);
 

--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -656,7 +656,7 @@ Result hidInitialize(void);
 void hidExit(void);
 void hidReset(void);
 
-Service* hidGetSessionService(void);
+Service* hidGetServiceSession(void);
 void* hidGetSharedmemAddr(void);
 
 void hidSetControllerLayout(HidControllerID id, HidControllerLayoutType layoutType);

--- a/nx/include/switch/services/hiddbg.h
+++ b/nx/include/switch/services/hiddbg.h
@@ -78,6 +78,7 @@ typedef struct {
 
 Result hiddbgInitialize(void);
 void hiddbgExit(void);
+Service* hiddbgGetServiceSession(void);
 
 /// Writes the input RGB colors to the spi-flash for the specified controller (offset 0x6050 size 0x6). See hidsys.h for UniquePadId. Only available with [3.0.0+].
 Result hiddbgUpdateControllerColor(u32 colorBody, u32 colorButtons, u64 UniquePadId);

--- a/nx/include/switch/services/hidsys.h
+++ b/nx/include/switch/services/hidsys.h
@@ -34,6 +34,7 @@ typedef struct {
 
 Result hidsysInitialize(void);
 void hidsysExit(void);
+Service* hidsysGetServiceSession(void);
 
 Result hidsysEnableAppletToGetInput(bool enable);
 

--- a/nx/include/switch/services/i2c.h
+++ b/nx/include/switch/services/i2c.h
@@ -57,6 +57,7 @@ typedef enum {
 
 Result i2cInitialize(void);
 void i2cExit(void);
+Service* i2cGetServiceSession(void);
 
 Result i2cOpenSession(I2cSession *out, I2cDevice dev);
 

--- a/nx/include/switch/services/irs.h
+++ b/nx/include/switch/services/irs.h
@@ -55,7 +55,7 @@ Result irsInitialize(void);
 /// Exit irs.
 void irsExit(void);
 
-Service* irsGetSessionService(void);
+Service* irsGetServiceSession(void);
 void* irsGetSharedmemAddr(void);
 
 /// (De)activate the IR sensor, this is automatically used by \ref irsExit. Must be called after irsInitialize() to activate the IR sensor.

--- a/nx/include/switch/services/lbl.h
+++ b/nx/include/switch/services/lbl.h
@@ -6,9 +6,11 @@
  */
 #pragma once
 #include "../types.h"
+#include "../services/sm.h"
 
 Result lblInitialize(void);
 void lblExit(void);
+Service* lblGetServiceSession(void);
 
 Result lblSwitchBacklightOn(u64 fade_time);
 Result lblSwitchBacklightOff(u64 fade_time);

--- a/nx/include/switch/services/lr.h
+++ b/nx/include/switch/services/lr.h
@@ -19,6 +19,7 @@ typedef struct {
 
 Result lrInitialize(void);
 void lrExit(void);
+Service* lrGetServiceSession(void);
 
 Result lrOpenLocationResolver(FsStorageId storage, LrLocationResolver* out);
 Result lrOpenRegisteredLocationResolver(LrRegisteredLocationResolver* out);

--- a/nx/include/switch/services/ncm.h
+++ b/nx/include/switch/services/ncm.h
@@ -76,6 +76,7 @@ typedef struct {
 
 Result ncmInitialize(void);
 void ncmExit(void);
+Service* ncmGetServiceSession(void);
 
 Result ncmOpenContentStorage(FsStorageId storage, NcmContentStorage* out);
 Result ncmOpenContentMetaDatabase(FsStorageId storage, NcmContentMetaDatabase* out);

--- a/nx/include/switch/services/pcv.h
+++ b/nx/include/switch/services/pcv.h
@@ -6,6 +6,7 @@
  */
 #pragma once
 #include "../types.h"
+#include "../services/sm.h"
 
 typedef enum {
     PcvModule_CpuBus            = 0,
@@ -192,6 +193,7 @@ typedef enum {
 
 Result pcvInitialize(void);
 void pcvExit(void);
+Service* pcvGetServiceSession(void);
 
 Result pcvGetModuleId(PcvModuleId *module_id, PcvModule module);
 

--- a/nx/include/switch/services/pdm.h
+++ b/nx/include/switch/services/pdm.h
@@ -161,6 +161,7 @@ typedef struct {
 
 Result pdmqryInitialize(void);
 void pdmqryExit(void);
+Service* pdmqueryGetServiceSession(void);
 
 /**
  * @brief Gets a list of \ref PdmApplicationEvent.

--- a/nx/include/switch/services/pl.h
+++ b/nx/include/switch/services/pl.h
@@ -27,6 +27,7 @@ typedef struct {
 
 Result plInitialize(void);
 void plExit(void);
+Service* plGetServiceSession(void);
 void* plGetSharedmemAddr(void);
 
 ///< Gets a specific shared-font via SharedFontType, see \ref PlSharedFontType.

--- a/nx/include/switch/services/psc.h
+++ b/nx/include/switch/services/psc.h
@@ -26,6 +26,7 @@ typedef struct {
 
 Result pscInitialize(void);
 void pscExit(void);
+Service* pscGetServiceSession(void);
 
 Result pscGetPmModule(PscPmModule *out, u16 module_id, const u16 *dependencies, size_t dependency_count, bool autoclear);
 

--- a/nx/include/switch/services/psm.h
+++ b/nx/include/switch/services/psm.h
@@ -30,6 +30,7 @@ typedef struct {
 
 Result psmInitialize(void);
 void psmExit(void);
+Service* psmGetServiceSession(void);
 
 Result psmGetBatteryChargePercentage(u32 *out);
 Result psmGetChargerType(ChargerType *out);

--- a/nx/include/switch/services/ro.h
+++ b/nx/include/switch/services/ro.h
@@ -11,12 +11,15 @@
 
 Result ldrRoInitialize(void);
 void ldrRoExit(void);
+Service* ldrRoGetServiceSession(void);
 
 Result ro1Initialize(void);
 void ro1Exit(void);
+Service* ro1GetServiceSession(void);
 
 Result roDmntInitialize(void);
 void roDmntExit(void);
+Service* roDmntGetServiceSession(void);
 
 Result ldrRoLoadNro(u64* out_address, u64 nro_address, u64 nro_size, u64 bss_address, u64 bss_size);
 Result ldrRoUnloadNro(u64 nro_address);

--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -9,6 +9,7 @@
 #pragma once
 #include "../result.h"
 #include "../kernel/event.h"
+#include "../services/sm.h"
 
 #define SET_MAX_NAME_SIZE 0x48
 #define SET_MAX_NICKNAME_SIZE 0x80
@@ -86,6 +87,7 @@ typedef struct {
 
 Result setInitialize(void);
 void setExit(void);
+Service* setGetServiceSession(void);
 
 /// Converts LanguageCode to Language.
 Result setMakeLanguage(u64 LanguageCode, s32 *Language);
@@ -114,6 +116,7 @@ Result setGetRegionCode(SetRegion *out);
 
 Result setsysInitialize(void);
 void setsysExit(void);
+Service* setsysGetServiceSession(void);
 
 /// Gets the current system theme.
 Result setsysGetColorSetId(ColorSetId *out);

--- a/nx/include/switch/services/spl.h
+++ b/nx/include/switch/services/spl.h
@@ -36,21 +36,27 @@ typedef enum {
 
 Result splInitialize(void);
 void splExit(void);
+Service* splGetServiceSession(void);
 
 Result splCryptoInitialize(void);
 void splCryptoExit(void);
+Service* splCryptoGetServiceSession(void);
 
 Result splSslInitialize(void);
 void splSslExit(void);
+Service* splSslGetServiceSession(void);
 
 Result splEsInitialize(void);
 void splEsExit(void);
+Service* splEsGetServiceSession(void);
 
 Result splFsInitialize(void);
 void splFsExit(void);
+Service* splFsGetServiceSession(void);
 
 Result splManuInitialize(void);
 void splManuExit(void);
+Service* splManuGetServiceSession(void);
 
 Result splGetConfig(SplConfigItem config_item, u64 *out_config);
 Result splUserExpMod(const void *input, const void *modulus, const void *exp, size_t exp_size, void *dst);

--- a/nx/include/switch/services/spsm.h
+++ b/nx/include/switch/services/spsm.h
@@ -6,9 +6,11 @@
  */
 #pragma once
 #include "../types.h"
+#include "../services/sm.h"
 
 Result spsmInitialize(void);
 void spsmExit(void);
+Service* spsmGetServiceSession(void);
 
 Result spsmShutdown(bool reboot);
 Result spsmPutErrorState(void);

--- a/nx/include/switch/services/time.h
+++ b/nx/include/switch/services/time.h
@@ -46,7 +46,7 @@ typedef struct {
 Result timeInitialize(void);
 void timeExit(void);
 
-Service* timeGetSessionService(void);
+Service* timeGetServiceSession(void);
 
 Result timeGetCurrentTime(TimeType type, u64 *timestamp);
 

--- a/nx/include/switch/services/usbds.h
+++ b/nx/include/switch/services/usbds.h
@@ -64,6 +64,7 @@ typedef enum {
 Result usbDsInitialize(void);
 /// Closes the usb:ds session. Any interfaces/endpoints which are left open are automatically closed, since otherwise usb-sysmodule won't fully reset usb:ds to defaults.
 void usbDsExit(void);
+Service* usbDsGetServiceSession(void);
 
 /// Helpers
 Result usbDsWaitReady(u64 timeout);

--- a/nx/include/switch/services/usbhs.h
+++ b/nx/include/switch/services/usbhs.h
@@ -104,6 +104,7 @@ typedef struct {
 /// Initialize/exit usb:hs.
 Result usbHsInitialize(void);
 void usbHsExit(void);
+Service* usbHsGetServiceSession(void);
 
 /// Returns the Event loaded during init with autoclear=false.
 /// Signaled when a device was removed.

--- a/nx/include/switch/services/wlaninf.h
+++ b/nx/include/switch/services/wlaninf.h
@@ -18,6 +18,7 @@ typedef enum {
 
 Result wlaninfInitialize(void);
 void wlaninfExit(void);
+Service* wlaninfGetServiceSession(void);
 
 Result wlaninfGetState(WlanInfState* out);
 

--- a/nx/source/services/acc.c
+++ b/nx/source/services/acc.c
@@ -30,7 +30,7 @@ void accountExit(void)
         serviceClose(&g_accSrv);
 }
 
-Service* accountGetService(void) {
+Service* accountGetServiceSession(void) {
     return &g_accSrv;
 }
 

--- a/nx/source/services/apm.c
+++ b/nx/source/services/apm.c
@@ -41,6 +41,11 @@ void apmExit(void)
     }
 }
 
+Service* apmGetServiceSession(void)
+{
+    return &g_apmSrv;    
+}
+
 static Result _apmGetSession(Service* srv, Service* srv_out, u64 cmd_id) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/apm.c
+++ b/nx/source/services/apm.c
@@ -41,8 +41,7 @@ void apmExit(void)
     }
 }
 
-Service* apmGetServiceSession(void)
-{
+Service* apmGetServiceSession(void) {
     return &g_apmSrv;    
 }
 

--- a/nx/source/services/auddev.c
+++ b/nx/source/services/auddev.c
@@ -47,8 +47,7 @@ void auddevExit(void) {
     }
 }
 
-Service* auddevGetServiceSession(void)
-{
+Service* auddevGetServiceSession(void) {
     return &g_auddevIAudioDevice;
 }
 

--- a/nx/source/services/auddev.c
+++ b/nx/source/services/auddev.c
@@ -47,6 +47,11 @@ void auddevExit(void) {
     }
 }
 
+Service* auddevGetServiceSession(void)
+{
+    return &g_auddevIAudioDevice;
+}
+
 static Result _auddevGetAudioDeviceService(Service* srv, Service* out_srv, u64 aruid) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/audren.c
+++ b/nx/source/services/audren.c
@@ -129,8 +129,7 @@ void audrenExit(void)
     tmemClose(&g_audrenWorkBuf);
 }
 
-Service* audrenGetServiceSession(void)
-{
+Service* audrenGetServiceSession(void) {
     return &g_audrenIAudioRenderer;
 }
 

--- a/nx/source/services/audren.c
+++ b/nx/source/services/audren.c
@@ -129,6 +129,11 @@ void audrenExit(void)
     tmemClose(&g_audrenWorkBuf);
 }
 
+Service* audrenGetServiceSession(void)
+{
+    return &g_audrenIAudioRenderer;
+}
+
 void audrenWaitFrame(void)
 {
     eventWait(&g_audrenEvent, U64_MAX);

--- a/nx/source/services/bpc.c
+++ b/nx/source/services/bpc.c
@@ -29,6 +29,11 @@ void bpcExit(void)
         serviceClose(&g_bpcSrv);
 }
 
+Service* bpcGetServiceSession(void)
+{
+    return &g_bpcSrv;
+}
+
 Result bpcShutdownSystem(void)
 {
     IpcCommand c;

--- a/nx/source/services/bpc.c
+++ b/nx/source/services/bpc.c
@@ -29,8 +29,7 @@ void bpcExit(void)
         serviceClose(&g_bpcSrv);
 }
 
-Service* bpcGetServiceSession(void)
-{
+Service* bpcGetServiceSession(void) {
     return &g_bpcSrv;
 }
 

--- a/nx/source/services/bsd.c
+++ b/nx/source/services/bsd.c
@@ -277,8 +277,7 @@ void bsdExit(void) {
     tmemClose(&g_bsdTmem);
 }
 
-Service* bsdGetServiceSession(void)
-{
+Service* bsdGetServiceSession(void) {
     return &g_bsdSrv;
 }
 

--- a/nx/source/services/bsd.c
+++ b/nx/source/services/bsd.c
@@ -277,6 +277,11 @@ void bsdExit(void) {
     tmemClose(&g_bsdTmem);
 }
 
+Service* bsdGetServiceSession(void)
+{
+    return &g_bsdSrv;
+}
+
 int bsdSocket(int domain, int type, int protocol) {
     return _bsdSocketCreationCommand(2, domain, type, protocol);
 }

--- a/nx/source/services/capssc.c
+++ b/nx/source/services/capssc.c
@@ -33,6 +33,11 @@ void capsscExit(void) {
         serviceClose(&g_capsscSrv);
 }
 
+Service* capsscGetServiceSession(void)
+{
+    return &g_capsscSrv;
+}
+
 Result capsscCaptureScreenshot(void* buf, size_t size, u32 inval, u64 width, u64 height, s64 buffer_count, s64 buffer_index, u64 timeout) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/capssc.c
+++ b/nx/source/services/capssc.c
@@ -33,8 +33,7 @@ void capsscExit(void) {
         serviceClose(&g_capsscSrv);
 }
 
-Service* capsscGetServiceSession(void)
-{
+Service* capsscGetServiceSession(void) {
     return &g_capsscSrv;
 }
 

--- a/nx/source/services/capssu.c
+++ b/nx/source/services/capssu.c
@@ -35,6 +35,11 @@ void capssuExit(void) {
         serviceClose(&g_capssuSrv);
 }
 
+Service* capssuGetServiceSession(void)
+{
+    return &g_capssuSrv;
+}
+
 static Result _capssuSaveScreenShotEx0(const void* buffer, size_t size, CapsScreenShotAttribute *attr, u32 unk, CapsApplicationAlbumEntry *out) {
     u64 AppletResourceUserId = 0;
     appletGetAppletResourceUserId(&AppletResourceUserId);

--- a/nx/source/services/capssu.c
+++ b/nx/source/services/capssu.c
@@ -35,8 +35,7 @@ void capssuExit(void) {
         serviceClose(&g_capssuSrv);
 }
 
-Service* capssuGetServiceSession(void)
-{
+Service* capssuGetServiceSession(void) {
     return &g_capssuSrv;
 }
 

--- a/nx/source/services/clkrst.c
+++ b/nx/source/services/clkrst.c
@@ -37,8 +37,7 @@ void clkrstExit(void) {
     }
 }
 
-Service* clkrstGetServiceSession(void)
-{
+Service* clkrstGetServiceSession(void) {
     return &g_clkrstSrv;
 }
 

--- a/nx/source/services/clkrst.c
+++ b/nx/source/services/clkrst.c
@@ -37,6 +37,11 @@ void clkrstExit(void) {
     }
 }
 
+Service* clkrstGetServiceSession(void)
+{
+    return &g_clkrstSrv;
+}
+
 Result clkrstOpenSession(ClkrstSession* session_out, PcvModuleId module_id, u32 unk) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/csrng.c
+++ b/nx/source/services/csrng.c
@@ -25,6 +25,11 @@ void csrngExit(void) {
         serviceClose(&g_csrngSrv);
 }
 
+Service* csrngGetServiceSession(void)
+{
+    return &g_csrngSrv;
+}
+
 Result csrngGetRandomBytes(void *out, size_t out_size) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/csrng.c
+++ b/nx/source/services/csrng.c
@@ -25,8 +25,7 @@ void csrngExit(void) {
         serviceClose(&g_csrngSrv);
 }
 
-Service* csrngGetServiceSession(void)
-{
+Service* csrngGetServiceSession(void) {
     return &g_csrngSrv;
 }
 

--- a/nx/source/services/fsldr.c
+++ b/nx/source/services/fsldr.c
@@ -39,8 +39,7 @@ void fsldrExit(void) {
         serviceClose(&g_fsldrSrv);
 }
 
-Service* fsldrGetServiceSession(void)
-{
+Service* fsldrGetServiceSession(void) {
     return &g_fsldrSrv;
 }
 

--- a/nx/source/services/fsldr.c
+++ b/nx/source/services/fsldr.c
@@ -39,6 +39,11 @@ void fsldrExit(void) {
         serviceClose(&g_fsldrSrv);
 }
 
+Service* fsldrGetServiceSession(void)
+{
+    return &g_fsldrSrv;
+}
+
 Result fsldrOpenCodeFileSystem(u64 tid, const char *path, FsFileSystem* out) {
     char send_path[FS_MAX_PATH+1] = {0};
     IpcCommand c;

--- a/nx/source/services/fspr.c
+++ b/nx/source/services/fspr.c
@@ -39,8 +39,7 @@ void fsprExit(void) {
         serviceClose(&g_fsprSrv);
 }
 
-Service* fsprGetServiceSession(void)
-{
+Service* fsprGetServiceSession(void) {
     return &g_fsprSrv;
 }
 

--- a/nx/source/services/fspr.c
+++ b/nx/source/services/fspr.c
@@ -39,6 +39,11 @@ void fsprExit(void) {
         serviceClose(&g_fsprSrv);
 }
 
+Service* fsprGetServiceSession(void)
+{
+    return &g_fsprSrv;
+}
+
 Result fsprRegisterProgram(u64 pid, u64 titleID, FsStorageId storageID, const void *fs_access_header, size_t fah_size, const void *fs_access_control, size_t fac_size) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/gpio.c
+++ b/nx/source/services/gpio.c
@@ -29,8 +29,7 @@ void gpioExit(void) {
     }
 }
 
-Service* gpioGetServiceSession(void)
-{
+Service* gpioGetServiceSession(void) {
     return &g_gpioSrv;
 }
 

--- a/nx/source/services/gpio.c
+++ b/nx/source/services/gpio.c
@@ -29,6 +29,11 @@ void gpioExit(void) {
     }
 }
 
+Service* gpioGetServiceSession(void)
+{
+    return &g_gpioSrv;
+}
+
 Result gpioOpenSession(GpioPadSession *out, GpioPadName name) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/hid.c
+++ b/nx/source/services/hid.c
@@ -167,7 +167,7 @@ void hidReset(void)
     rwlockWriteUnlock(&g_hidLock);
 }
 
-Service* hidGetSessionService(void) {
+Service* hidGetServiceSession(void) {
     return &g_hidSrv;
 }
 

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -37,6 +37,11 @@ void hiddbgExit(void) {
     }
 }
 
+Service* hiddbgGetServiceSession(void)
+{
+    return &g_hiddbgSrv;
+}
+
 static Result _hiddbgCmdNoIO(u64 cmd_id) {
     Result rc;
 

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -37,8 +37,7 @@ void hiddbgExit(void) {
     }
 }
 
-Service* hiddbgGetServiceSession(void)
-{
+Service* hiddbgGetServiceSession(void) {
     return &g_hiddbgSrv;
 }
 

--- a/nx/source/services/hidsys.c
+++ b/nx/source/services/hidsys.c
@@ -38,6 +38,11 @@ void hidsysExit(void) {
     }
 }
 
+Service* hidsysGetServiceSession(void)
+{
+    return &g_hidsysSrv;
+}
+
 Result hidsysEnableAppletToGetInput(bool enable) {  
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/hidsys.c
+++ b/nx/source/services/hidsys.c
@@ -38,8 +38,7 @@ void hidsysExit(void) {
     }
 }
 
-Service* hidsysGetServiceSession(void)
-{
+Service* hidsysGetServiceSession(void) {
     return &g_hidsysSrv;
 }
 

--- a/nx/source/services/i2c.c
+++ b/nx/source/services/i2c.c
@@ -33,6 +33,11 @@ void i2cExit(void) {
     }
 }
 
+Service* i2cGetServiceSession(void)
+{
+    return &g_i2cSrv;
+}
+
 Result i2cOpenSession(I2cSession *out, I2cDevice dev) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/i2c.c
+++ b/nx/source/services/i2c.c
@@ -33,8 +33,7 @@ void i2cExit(void) {
     }
 }
 
-Service* i2cGetServiceSession(void)
-{
+Service* i2cGetServiceSession(void) {
     return &g_i2cSrv;
 }
 

--- a/nx/source/services/irs.c
+++ b/nx/source/services/irs.c
@@ -135,7 +135,7 @@ static void _IrsCameraEntryFree(IrsCameraEntry *entry) {
     memset(entry, 0, sizeof(IrsCameraEntry));
 }
 
-Service* irsGetSessionService(void) {
+Service* irsGetServiceSession(void) {
     return &g_irsSrv;
 }
 

--- a/nx/source/services/lbl.c
+++ b/nx/source/services/lbl.c
@@ -29,8 +29,7 @@ void lblExit(void) {
     }
 }
 
-Service* lblGetServiceSession(void)
-{
+Service* lblGetServiceSession(void) {
     return &g_lblSrv;
 }
 

--- a/nx/source/services/lbl.c
+++ b/nx/source/services/lbl.c
@@ -29,6 +29,11 @@ void lblExit(void) {
     }
 }
 
+Service* lblGetServiceSession(void)
+{
+    return &g_lblSrv;
+}
+
 static Result _lblCmdNoIO(u64 cmd_id) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/lr.c
+++ b/nx/source/services/lr.c
@@ -27,8 +27,7 @@ void lrExit(void) {
     }
 }
 
-Service* lrGetServiceSession(void)
-{
+Service* lrGetServiceSession(void) {
     return &g_managerSrv;
 }
 

--- a/nx/source/services/lr.c
+++ b/nx/source/services/lr.c
@@ -27,6 +27,11 @@ void lrExit(void) {
     }
 }
 
+Service* lrGetServiceSession(void)
+{
+    return &g_managerSrv;
+}
+
 Result lrOpenLocationResolver(FsStorageId storage, LrLocationResolver* out) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/ncm.c
+++ b/nx/source/services/ncm.c
@@ -20,8 +20,7 @@ void ncmExit(void) {
     }
 }
 
-Service* ncmGetServiceSession(void)
-{
+Service* ncmGetServiceSession(void) {
     return &g_ncmSrv;
 }
 

--- a/nx/source/services/ncm.c
+++ b/nx/source/services/ncm.c
@@ -20,6 +20,11 @@ void ncmExit(void) {
     }
 }
 
+Service* ncmGetServiceSession(void)
+{
+    return &g_ncmSrv;
+}
+
 Result ncmOpenContentStorage(FsStorageId storage, NcmContentStorage* out) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/pcv.c
+++ b/nx/source/services/pcv.c
@@ -30,6 +30,11 @@ void pcvExit(void) {
     }
 }
 
+Service* pcvGetServiceSession(void)
+{
+    return &g_pcvSrv;
+}
+
 Result pcvGetModuleId(PcvModuleId *module_id, PcvModule module) {
     static const PcvModuleId s_moduleIdMap[PcvModule_Count] = {
         PcvModuleId_CpuBus,         PcvModuleId_GPU,            PcvModuleId_I2S1,               PcvModuleId_I2S2,

--- a/nx/source/services/pcv.c
+++ b/nx/source/services/pcv.c
@@ -30,8 +30,7 @@ void pcvExit(void) {
     }
 }
 
-Service* pcvGetServiceSession(void)
-{
+Service* pcvGetServiceSession(void) {
     return &g_pcvSrv;
 }
 

--- a/nx/source/services/pdm.c
+++ b/nx/source/services/pdm.c
@@ -29,6 +29,11 @@ void pdmqryExit(void) {
         serviceClose(&g_pdmqrySrv);
 }
 
+Service* pdmqryGetServiceSession(void)
+{
+    return &g_pdmqrySrv;
+}
+
 static Result _pdmqryQueryEvent(u64 cmd_id, u32 entryindex, void* events, size_t entrysize, s32 count, s32 *total_out) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/pdm.c
+++ b/nx/source/services/pdm.c
@@ -29,8 +29,7 @@ void pdmqryExit(void) {
         serviceClose(&g_pdmqrySrv);
 }
 
-Service* pdmqryGetServiceSession(void)
-{
+Service* pdmqryGetServiceSession(void) {
     return &g_pdmqrySrv;
 }
 

--- a/nx/source/services/pl.c
+++ b/nx/source/services/pl.c
@@ -53,6 +53,11 @@ void plExit(void)
     }
 }
 
+Service* plGetServiceSession(void)
+{
+    return &g_plSrv;
+}
+
 void* plGetSharedmemAddr(void) {
     return shmemGetAddr(&g_plSharedmem);
 }

--- a/nx/source/services/pl.c
+++ b/nx/source/services/pl.c
@@ -53,8 +53,7 @@ void plExit(void)
     }
 }
 
-Service* plGetServiceSession(void)
-{
+Service* plGetServiceSession(void) {
     return &g_plSrv;
 }
 

--- a/nx/source/services/psc.c
+++ b/nx/source/services/psc.c
@@ -45,6 +45,11 @@ void pscExit(void) {
     }
 }
 
+Service* pscGetServiceSession(void)
+{
+    return &g_pscSrv;
+}
+
 Result pscGetPmModule(PscPmModule *out, u16 module_id, const u16 *dependencies, size_t dependency_count, bool autoclear) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/psc.c
+++ b/nx/source/services/psc.c
@@ -45,8 +45,7 @@ void pscExit(void) {
     }
 }
 
-Service* pscGetServiceSession(void)
-{
+Service* pscGetServiceSession(void) {
     return &g_pscSrv;
 }
 

--- a/nx/source/services/psm.c
+++ b/nx/source/services/psm.c
@@ -37,8 +37,7 @@ void psmExit(void) {
     }
 }
 
-Service* psmGetServiceSession(void)
-{
+Service* psmGetServiceSession(void) {
     return &g_psmSrv;
 }
 

--- a/nx/source/services/psm.c
+++ b/nx/source/services/psm.c
@@ -37,6 +37,11 @@ void psmExit(void) {
     }
 }
 
+Service* psmGetServiceSession(void)
+{
+    return &g_psmSrv;
+}
+
 static Result _psmGetOutU32(u64 cmd_id, u32 *out) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/ro.c
+++ b/nx/source/services/ro.c
@@ -37,6 +37,11 @@ void ldrRoExit(void) {
         serviceClose(&g_roSrv);
 }
 
+Service* ldrRoGetServiceSession(void)
+{
+    return &g_roSrv;
+}
+
 Result ro1Initialize(void) {
     if (hosversionBefore(7,0,0)) return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
 
@@ -59,6 +64,11 @@ void ro1Exit(void) {
         serviceClose(&g_ro1Srv);
 }
 
+Service* ro1GetServiceSession(void)
+{
+    return &g_ro1Srv;
+}
+
 Result roDmntInitialize(void) {
     if (hosversionBefore(3,0,0)) return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
 
@@ -73,6 +83,11 @@ Result roDmntInitialize(void) {
 void roDmntExit(void) {
     if (atomicDecrement64(&g_dmntRefCnt) == 0)
         serviceClose(&g_dmntSrv);
+}
+
+Service* roDmntGetServiceSession(void)
+{
+    return &g_dmntSrv;
 }
 
 Result _rosrvInitialize(Service* srv) {

--- a/nx/source/services/ro.c
+++ b/nx/source/services/ro.c
@@ -37,8 +37,7 @@ void ldrRoExit(void) {
         serviceClose(&g_roSrv);
 }
 
-Service* ldrRoGetServiceSession(void)
-{
+Service* ldrRoGetServiceSession(void) {
     return &g_roSrv;
 }
 
@@ -64,8 +63,7 @@ void ro1Exit(void) {
         serviceClose(&g_ro1Srv);
 }
 
-Service* ro1GetServiceSession(void)
-{
+Service* ro1GetServiceSession(void) {
     return &g_ro1Srv;
 }
 
@@ -85,8 +83,7 @@ void roDmntExit(void) {
         serviceClose(&g_dmntSrv);
 }
 
-Service* roDmntGetServiceSession(void)
-{
+Service* roDmntGetServiceSession(void) {
     return &g_dmntSrv;
 }
 

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -45,8 +45,7 @@ void setExit(void)
     }
 }
 
-Service* setGetServiceSession(void)
-{
+Service* setGetServiceSession(void) {
     return &g_setSrv;
 }
 
@@ -67,8 +66,7 @@ void setsysExit(void)
     }
 }
 
-Service* setsysGetSessionService(void)
-{
+Service* setsysGetSessionService(void) {
     return &g_setsysSrv;
 }
 

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -45,6 +45,11 @@ void setExit(void)
     }
 }
 
+Service* setGetServiceSession(void)
+{
+    return &g_setSrv;
+}
+
 Result setsysInitialize(void)
 {
     atomicIncrement64(&g_refCntSys);
@@ -60,6 +65,11 @@ void setsysExit(void)
     if (atomicDecrement64(&g_refCntSys) == 0) {
         serviceClose(&g_setsysSrv);
     }
+}
+
+Service* setsysGetSessionService(void)
+{
+    return &g_setsysSrv;
 }
 
 static Result setInitializeLanguageCodesCache(void) {

--- a/nx/source/services/spl.c
+++ b/nx/source/services/spl.c
@@ -18,6 +18,8 @@ static Service* _splGetRsaSrv(void);
 
 static Service* _splGetEsSrv(void);
 static Service* _splGetFsSrv(void);
+static Service* _splGetSslSrv(void);
+static Service* _splGetManuSrv(void);
 
 Service* _splGetGeneralSrv(void) {
     if (hosversionBefore(4,0,0)) {
@@ -71,6 +73,14 @@ Service* _splGetFsSrv(void) {
     return hosversionAtLeast(4,0,0) ? &g_splFsSrv : &g_splSrv;
 }
 
+Service* _splGetSslSrv(void) {
+    return hosversionAtLeast(4,0,0) ? &g_splSslSrv : &g_splSrv;
+}
+
+Service* _splGetManuSrv(void) {
+    return hosversionAtLeast(4,0,0) ? &g_splManuSrv : &g_splSrv;
+}
+
 /* There are like six services, so these helpers will initialize/exit the relevant services. */
 static Result _splSrvInitialize(Service* srv, u64 *refcnt, const char *name) {
     atomicIncrement64(refcnt);
@@ -95,7 +105,7 @@ void splExit(void) {
 }
 
 Service* splGetServiceSession(void) {
-    return &g_splSrv;
+    return _splGetGeneralSrv();
 }
 
 Result splCryptoInitialize(void) {
@@ -115,7 +125,7 @@ void splCryptoExit(void) {
 }
 
 Service* splCryptoGetServiceSession(void) {
-    return &g_splCryptoSrv;
+    return _splGetCryptoSrv();
 }
 
 Result splSslInitialize(void) {
@@ -135,7 +145,7 @@ void splSslExit(void) {
 }
 
 Service* splSslGetServiceSession(void) {
-    return &g_splSslSrv;
+    return _splGetSslSrv();
 }
 
 Result splEsInitialize(void) {
@@ -155,7 +165,7 @@ void splEsExit(void) {
 }
 
 Service* splEsGetServiceSession(void) {
-    return &g_splEsSrv;
+    return _splGetEsSrv();
 }
 
 Result splFsInitialize(void) {
@@ -175,7 +185,7 @@ void splFsExit(void) {
 }
 
 Service* splFsGetServiceSession(void) {
-    return &g_splFsSrv;
+    return _splGetFsSrv();
 }
 
 Result splManuInitialize(void) {
@@ -187,7 +197,7 @@ void splManuExit(void) {
 }
 
 Service* splManuGetServiceSession(void) {
-    return &g_splManuSrv;
+    return _splGetManuSrv();
 }
 
 

--- a/nx/source/services/spl.c
+++ b/nx/source/services/spl.c
@@ -94,6 +94,11 @@ void splExit(void) {
     return _splSrvExit(&g_splSrv, &g_splRefCnt);
 }
 
+Service* splGetServiceSession(void)
+{
+    return &g_splSrv;
+}
+
 Result splCryptoInitialize(void) {
     if (hosversionAtLeast(4,0,0)) {
         return _splSrvInitialize(&g_splCryptoSrv, &g_splCryptoRefCnt, "spl:mig");
@@ -108,6 +113,11 @@ void splCryptoExit(void) {
     } else {
         return splExit();
     }
+}
+
+Service* splCryptogetServiceSession(void)
+{
+    return &g_splCryptoSrv;
 }
 
 Result splSslInitialize(void) {
@@ -126,6 +136,11 @@ void splSslExit(void) {
     }
 }
 
+Service* splSslGetServiceSession(void)
+{
+    return &g_splSslSrv;
+}
+
 Result splEsInitialize(void) {
     if (hosversionAtLeast(4,0,0)) {
         return _splSrvInitialize(&g_splEsSrv, &g_splEsRefCnt, "spl:es");
@@ -140,6 +155,11 @@ void splEsExit(void) {
     } else {
         return splExit();
     }
+}
+
+Service* splEsGetServiceSession(void)
+{
+    return &g_splEsSrv;
 }
 
 Result splFsInitialize(void) {
@@ -158,12 +178,22 @@ void splFsExit(void) {
     }
 }
 
+Service* splFsGetServiceSession(void)
+{
+    return &g_splFsSrv;
+}
+
 Result splManuInitialize(void) {
     return _splSrvInitialize(&g_splManuSrv, &g_splManuRefCnt, "spl:manu");
 }
 
 void splManuExit(void) {
      return _splSrvExit(&g_splManuSrv, &g_splManuRefCnt);
+}
+
+Service* splManuGetServiceSession(void)
+{
+    return &g_splManuSrv;
 }
 
 

--- a/nx/source/services/spl.c
+++ b/nx/source/services/spl.c
@@ -94,8 +94,7 @@ void splExit(void) {
     return _splSrvExit(&g_splSrv, &g_splRefCnt);
 }
 
-Service* splGetServiceSession(void)
-{
+Service* splGetServiceSession(void) {
     return &g_splSrv;
 }
 
@@ -115,8 +114,7 @@ void splCryptoExit(void) {
     }
 }
 
-Service* splCryptogetServiceSession(void)
-{
+Service* splCryptogetServiceSession(void) {
     return &g_splCryptoSrv;
 }
 
@@ -136,8 +134,7 @@ void splSslExit(void) {
     }
 }
 
-Service* splSslGetServiceSession(void)
-{
+Service* splSslGetServiceSession(void) {
     return &g_splSslSrv;
 }
 
@@ -157,8 +154,7 @@ void splEsExit(void) {
     }
 }
 
-Service* splEsGetServiceSession(void)
-{
+Service* splEsGetServiceSession(void) {
     return &g_splEsSrv;
 }
 
@@ -178,8 +174,7 @@ void splFsExit(void) {
     }
 }
 
-Service* splFsGetServiceSession(void)
-{
+Service* splFsGetServiceSession(void) {
     return &g_splFsSrv;
 }
 
@@ -191,8 +186,7 @@ void splManuExit(void) {
      return _splSrvExit(&g_splManuSrv, &g_splManuRefCnt);
 }
 
-Service* splManuGetServiceSession(void)
-{
+Service* splManuGetServiceSession(void) {
     return &g_splManuSrv;
 }
 

--- a/nx/source/services/spl.c
+++ b/nx/source/services/spl.c
@@ -114,7 +114,7 @@ void splCryptoExit(void) {
     }
 }
 
-Service* splCryptogetServiceSession(void) {
+Service* splCryptoGetServiceSession(void) {
     return &g_splCryptoSrv;
 }
 

--- a/nx/source/services/spsm.c
+++ b/nx/source/services/spsm.c
@@ -29,6 +29,11 @@ void spsmExit(void) {
     }
 }
 
+Service* spsmGetServiceSession(void)
+{
+    return &g_spsmSrv;
+}
+
 Result spsmShutdown(bool reboot) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/spsm.c
+++ b/nx/source/services/spsm.c
@@ -29,8 +29,7 @@ void spsmExit(void) {
     }
 }
 
-Service* spsmGetServiceSession(void)
-{
+Service* spsmGetServiceSession(void) {
     return &g_spsmSrv;
 }
 

--- a/nx/source/services/time.c
+++ b/nx/source/services/time.c
@@ -60,7 +60,7 @@ void timeExit(void)
     }
 }
 
-Service* timeGetSessionService(void) {
+Service* timeGetServiceSession(void) {
     return &g_timeSrv;
 }
 

--- a/nx/source/services/usbds.c
+++ b/nx/source/services/usbds.c
@@ -78,6 +78,11 @@ void usbDsExit(void)
     serviceClose(&g_usbDsSrv);
 }
 
+Service* usbDsGetServiceSession(void)
+{
+    return &g_usbDsSrv;
+}
+
 Event* usbDsGetStateChangeEvent(void)
 {
     return &g_usbDsStateChangeEvent;

--- a/nx/source/services/usbds.c
+++ b/nx/source/services/usbds.c
@@ -78,8 +78,7 @@ void usbDsExit(void)
     serviceClose(&g_usbDsSrv);
 }
 
-Service* usbDsGetServiceSession(void)
-{
+Service* usbDsGetServiceSession(void) {
     return &g_usbDsSrv;
 }
 

--- a/nx/source/services/usbhs.c
+++ b/nx/source/services/usbhs.c
@@ -52,6 +52,11 @@ void usbHsExit(void) {
     serviceClose(&g_usbHsSrv);
 }
 
+Service* usbHsGetServiceSession(void)
+{
+    return &g_usbHsSrv;
+}
+
 Event* usbHsGetInterfaceStateChangeEvent(void) {
     return &g_usbHsInterfaceStateChangeEvent;
 }

--- a/nx/source/services/usbhs.c
+++ b/nx/source/services/usbhs.c
@@ -52,8 +52,7 @@ void usbHsExit(void) {
     serviceClose(&g_usbHsSrv);
 }
 
-Service* usbHsGetServiceSession(void)
-{
+Service* usbHsGetServiceSession(void) {
     return &g_usbHsSrv;
 }
 

--- a/nx/source/services/wlaninf.c
+++ b/nx/source/services/wlaninf.c
@@ -36,6 +36,11 @@ void wlaninfExit(void) {
     }
 }
 
+Service* wlaninfGetServiceSession(void)
+{
+    return &g_wlaninfSrv;
+}
+
 Result wlaninfGetState(WlanInfState* out) {
     IpcCommand c;
     ipcInitialize(&c);

--- a/nx/source/services/wlaninf.c
+++ b/nx/source/services/wlaninf.c
@@ -36,8 +36,7 @@ void wlaninfExit(void) {
     }
 }
 
-Service* wlaninfGetServiceSession(void)
-{
+Service* wlaninfGetServiceSession(void) {
     return &g_wlaninfSrv;
 }
 


### PR DESCRIPTION
This is mainly for consistency, since some services have them but most don't. Also it's useful for making IPC calls that aren't in libnx, whether that be for testing them before making a PR to libnx or otherwise. It could also be used to send IPC calls to services that were extended by CFW.

Some services already had a `GetSessionService` or `GetService` function, but I renamed them to `GetServiceSession` to be consistent with the rest of the functions.

There were also some services I didn't add functions for because they have multiple service handles in them:
- applet
- audin
- audout
- nfc
- nifm
- ns
- nv
- pctl
- vi

I'm not sure what to do with them, but I saw that time has multiple service handles and it had a function to get only the main service, so maybe those services should be like time?

There were also a few services that I didn't add functions for because their services aren't stored, but are acquired in each call:
- fatal
- hwopus
- sfdnsres

I figure anyone who needs to send IPC calls to those services can also get the handle themselves beforehand, but I figured I'd mention them anyways.