### PR TITLE
Added ability to get raw `UsbDs` structs from `usbComms`.

### DIFF
--- a/nx/include/switch/runtime/devices/usb_comms.h
+++ b/nx/include/switch/runtime/devices/usb_comms.h
@@ -40,7 +40,7 @@ size_t usbCommsReadEx(void* buffer, size_t size, u32 interface);
 size_t usbCommsWriteEx(const void* buffer, size_t size, u32 interface);
 
 /// Gets the raw usbDs data for the default usbComms interface.
-Result usbCommsGetInfo(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out);
+Result usbCommsGetInfo(UsbDsInterface ** interface_data, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out);
 
 /// Same as usbCommsGetInfo except with the specified interface. 
-Result usbCommsGetInfoEx(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out, u32 interface);
+Result usbCommsGetInfoEx(UsbDsInterface ** interface_data, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out, u32 interface);

--- a/nx/include/switch/runtime/devices/usb_comms.h
+++ b/nx/include/switch/runtime/devices/usb_comms.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 #include "../../types.h"
+#include "../../services/usbds.h"
 
 typedef struct {
     u8 bInterfaceClass;
@@ -37,3 +38,9 @@ size_t usbCommsReadEx(void* buffer, size_t size, u32 interface);
 
 /// Same as usbCommsWrite except with the specified interface.
 size_t usbCommsWriteEx(const void* buffer, size_t size, u32 interface);
+
+/// Gets the raw usbDs data for the default usbComms interface.
+Result usbCommsGetInfo(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out);
+
+/// Same as usbCommsGetInfo except with the specified interface. 
+Result usbCommsGetInfoEx(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out, u32 interface);

--- a/nx/source/runtime/devices/usb_comms.c
+++ b/nx/source/runtime/devices/usb_comms.c
@@ -613,7 +613,7 @@ Result usbCommsGetInfoEx(UsbDsInterface ** interface_data, UsbDsEndpoint ** endp
     else {
         *interface_data = inter->interface;
         *endpoint_in = inter->endpoint_in;
-        *endpoint_out = outter->endpoint_out;
+        *endpoint_out = inter->endpoint_out;
         rc = 0;
     }
 

--- a/nx/source/runtime/devices/usb_comms.c
+++ b/nx/source/runtime/devices/usb_comms.c
@@ -599,3 +599,27 @@ size_t usbCommsWrite(const void* buffer, size_t size)
     return usbCommsWriteEx(buffer, size, 0);
 }
 
+Result usbCommsGetInfoEx(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out, u32 interface) {
+    
+    usbCommsInterface *inter = &g_usbCommsInterfaces[interface];
+    Result rc;
+
+    if interface >= TOTAL_INTERFACES || !inter->initialized {
+        *interface = NULL;
+        *endpoint_in = NULL;
+        *endpoint_out = NULL; 
+        rc = MAKERESULT(Module_Libnx, LibnxError_NotInitialized);
+    }
+    else {
+        *interface = inter->interface;
+        *endpoint_in = inter->endpoint_in;
+        *endpoint_out = outter->endpoint_out;
+        rc = 0;
+    }
+
+    return rc;
+}
+
+Result usbCommsGetInfo(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out) {
+    return usbCommsGetInfoEx(interface, endpoint_in, endpoint_out, 0);
+}

--- a/nx/source/runtime/devices/usb_comms.c
+++ b/nx/source/runtime/devices/usb_comms.c
@@ -599,19 +599,19 @@ size_t usbCommsWrite(const void* buffer, size_t size)
     return usbCommsWriteEx(buffer, size, 0);
 }
 
-Result usbCommsGetInfoEx(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out, u32 interface) {
+Result usbCommsGetInfoEx(UsbDsInterface ** interface_data, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out, u32 interface) {
     
     usbCommsInterface *inter = &g_usbCommsInterfaces[interface];
     Result rc;
 
-    if interface >= TOTAL_INTERFACES || !inter->initialized {
-        *interface = NULL;
+    if(interface >= TOTAL_INTERFACES || !inter->initialized){
+        *interface_data = NULL;
         *endpoint_in = NULL;
         *endpoint_out = NULL; 
         rc = MAKERESULT(Module_Libnx, LibnxError_NotInitialized);
     }
     else {
-        *interface = inter->interface;
+        *interface_data = inter->interface;
         *endpoint_in = inter->endpoint_in;
         *endpoint_out = outter->endpoint_out;
         rc = 0;
@@ -620,6 +620,6 @@ Result usbCommsGetInfoEx(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_
     return rc;
 }
 
-Result usbCommsGetInfo(UsbDsInterface ** interface, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out) {
-    return usbCommsGetInfoEx(interface, endpoint_in, endpoint_out, 0);
+Result usbCommsGetInfo(UsbDsInterface ** interface_data, UsbDsEndpoint ** endpoint_in, UsbDsEndpoint ** endpoint_out) {
+    return usbCommsGetInfoEx(interface_data, endpoint_in, endpoint_out, 0);
 }


### PR DESCRIPTION
This would allow for non-infinite timeouts on read and write, async IO, and better error handling for users while still allowing us to piggyback off of `usbComms`'s boilerplate reducers. 

Note that I'm not particularly attached to this specific API, so if someone wants to close this and implement it in a different way I'm all for it. Also note that my C is a bit rusty at best, so if there's something off please tell me. 