### PR TITLE
svcGetInfo id0 should be an u32

### DIFF
--- a/nx/include/switch/kernel/svc.h
+++ b/nx/include/switch/kernel/svc.h
@@ -593,7 +593,7 @@ void NORETURN svcReturnFromException(Result res);
  * @remark The full list of property IDs can be found on the <a href="https://switchbrew.org/wiki/SVC#svcGetInfo">switchbrew.org wiki</a>.
  * @note Syscall number 0x29.
  */
-Result svcGetInfo(u64* out, u64 id0, Handle handle, u64 id1);
+Result svcGetInfo(u64* out, u32 id0, Handle handle, u64 id1);
 
 ///@}
 


### PR DESCRIPTION
svcGetInfo uses an u32 for id0 in the kernel (which moves W1 and not X1).