### PR TITLE
Add fsdevDeleteDevice function

### DIFF
--- a/nx/include/switch/runtime/devices/fs_dev.h
+++ b/nx/include/switch/runtime/devices/fs_dev.h
@@ -25,9 +25,12 @@ typedef struct
 /// Initializes and mounts the sdmc device if accessible. Also initializes current working directory to point to the folder containing the path to the executable (argv[0]), if it is provided by the environment.
 Result fsdevMountSdmc(void);
 
-/// Mounts the input fs with the specified device name. fsdev will handle closing the fs when required, including when fsdevMountDevice() fails.
+/// Mounts the input fs with the specified device name. fsdev will handle closing the fs when required (this can be avoided by unmounting it with fsdevDeleteDevice), including when fsdevMountDevice() fails.
 /// Returns -1 when any errors occur.
 int fsdevMountDevice(const char *name, FsFileSystem fs);
+
+/// Unmounts the specified device without closing its fs service.
+int fsdevDeleteDevice(const char *name);
 
 /// Unmounts the specified device.
 int fsdevUnmountDevice(const char *name);

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -335,7 +335,6 @@ static int _fsdevUnmountDeviceStruct(fsdev_fsdevice *device)
   strncat(name, ":", sizeof(name)-strlen(name)-1);
 
   RemoveDevice(name);
-  fsFsClose(&device->fs);
 
   if(device->id == fsdev_fsdevice_default)
     fsdev_fsdevice_default = -1;
@@ -349,7 +348,7 @@ static int _fsdevUnmountDeviceStruct(fsdev_fsdevice *device)
   return 0;
 }
 
-int fsdevUnmountDevice(const char *name)
+int fsdevDeleteDevice(const char *name)
 {
   fsdev_fsdevice *device;
 
@@ -358,6 +357,21 @@ int fsdevUnmountDevice(const char *name)
     return -1;
 
   return _fsdevUnmountDeviceStruct(device);
+}
+
+int fsdevUnmountDevice(const char *name)
+{
+  fsdev_fsdevice *device;
+
+  device = fsdevFindDevice(name);
+  if(device==NULL)
+    return -1;
+
+  int ret = _fsdevUnmountDeviceStruct(device);
+  if(ret==0)
+    fsFsClose(&device->fs);
+  
+  return ret;
 }
 
 Result fsdevCommitDevice(const char *name)


### PR DESCRIPTION
This way one can unmount filesystems without closing them (in case they would be used later without fsdev/stdio)