### PR TITLE
Require whole mount name to match when finding a romfs

### DIFF
--- a/nx/source/runtime/devices/romfs_dev.c
+++ b/nx/source/runtime/devices/romfs_dev.c
@@ -170,7 +170,7 @@ static romfs_mount *romfsFindMount(const char *name)
         }
         else if(mount->setup) //Find the mount with the input name.
         {
-            if(strncmp(mount->name, name, strlen(mount->name))==0)
+            if(strncmp(mount->name, name, sizeof(mount->name)-1)==0)
                 return mount;
         }
     }

--- a/nx/source/runtime/devices/romfs_dev.c
+++ b/nx/source/runtime/devices/romfs_dev.c
@@ -170,7 +170,7 @@ static romfs_mount *romfsFindMount(const char *name)
         }
         else if(mount->setup) //Find the mount with the input name.
         {
-            if(strncmp(mount->name, name, sizeof(mount->name)-1)==0)
+            if(strncmp(mount->name, name, sizeof(mount->name))==0)
                 return mount;
         }
     }


### PR DESCRIPTION
Before, only the first letters of the mount name had to match, so that if you had a romfs mounted at `romfs` and tried to unmount `romfshhhhhh` it would still unmount `romfs`