### PR TITLE
hid: set SYSTEM/SYSTEM_EXT as supported styles.

### DIFF
--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -222,6 +222,9 @@ typedef enum
     TYPE_JOYCON_PAIR   = BIT(2),
     TYPE_JOYCON_LEFT   = BIT(3),
     TYPE_JOYCON_RIGHT  = BIT(4),
+
+    TYPE_SYSTEM_EXT    = BIT(29),
+    TYPE_SYSTEM        = BIT(30),
 } HidControllerType;
 
 typedef enum

--- a/nx/source/services/hid.c
+++ b/nx/source/services/hid.c
@@ -97,7 +97,7 @@ Result hidInitialize(void)
         rc = _hidActivateNpad();
 
     if (R_SUCCEEDED(rc))
-        rc = hidSetSupportedNpadStyleSet(TYPE_PROCONTROLLER | TYPE_HANDHELD | TYPE_JOYCON_PAIR | TYPE_JOYCON_LEFT | TYPE_JOYCON_RIGHT);
+        rc = hidSetSupportedNpadStyleSet(TYPE_PROCONTROLLER | TYPE_HANDHELD | TYPE_JOYCON_PAIR | TYPE_JOYCON_LEFT | TYPE_JOYCON_RIGHT | TYPE_SYSTEM_EXT | TYPE_SYSTEM);
 
     if (R_SUCCEEDED(rc))
         rc = hidSetSupportedNpadIdType(idbuf, 9);


### PR DESCRIPTION
Starting in 9.0.0, HID shared memory no longer populates the SystemExt controller (which libnx calls LAYOUT_DEFAULT) unless it is explicitly set as supported. This changes hidInitialize() to set it and System as supported.