### PR TITLE
virtmem: fix incorrect bounds check

### DIFF
--- a/nx/source/kernel/virtmem.c
+++ b/nx/source/kernel/virtmem.c
@@ -119,7 +119,7 @@ void* virtmemReserve(size_t size) {
             continue;
         }
 
-        if (size > meminfo.size) {
+        if (addr + size > meminfo.addr + meminfo.size) {
             // We can't fit in this region, let's move past it.
             addr = meminfo.addr + meminfo.size;
             continue;
@@ -190,7 +190,7 @@ void* virtmemReserveStack(size_t size)
             continue;
         }
 
-        if (size > meminfo.size) {
+        if (addr + size > meminfo.addr + meminfo.size) {
             // We can't fit in this region, let's move past it.
             addr = meminfo.addr + meminfo.size;
             continue;


### PR DESCRIPTION
libnx checks size directly against region size, without accounting for offset into memory region. Due to the 0x1000 addition of guard pages, this issue causes libnx to decide a region is acceptable for reservation when it is 0x1000 too small (or causes other bad checks if the region is the first one considered).