### PR TITLE
hiddbg: Add a function to get Hdls' TransferMemory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# Nintendo Switch AArch64-only userland library.
-Based on libctru.
+Used for building sys-con.
 
-[![Build status](https://doozer.io/badge/switchbrew/libnx/buildstatus/master)](https://doozer.io/switchbrew/libnx)
-
-# Install instructions
-See [Switchbrew](https://switchbrew.org/wiki/Setting_up_Development_Environment).
+At the current moment i can't figure out how to build it locally, so replace the libnx folder with this in devkitpro.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
-Used for building sys-con.
+# Nintendo Switch AArch64-only userland library.
+Based on libctru.
 
-At the current moment i can't figure out how to build it locally, so replace the libnx folder with this in devkitpro.
+[![Build status](https://doozer.io/badge/switchbrew/libnx/buildstatus/master)](https://doozer.io/switchbrew/libnx)
+
+# Install instructions
+See [Switchbrew](https://switchbrew.org/wiki/Setting_up_Development_Environment).

--- a/nx/include/switch/services/hiddbg.h
+++ b/nx/include/switch/services/hiddbg.h
@@ -182,6 +182,9 @@ Result hiddbgAttachHdlsWorkBuffer(void);
 /// Exit Hdls, must be called at some point prior to hiddbgExit. Only available with [7.0.0+].
 Result hiddbgReleaseHdlsWorkBuffer(void);
 
+/// Gets the Tmem pointer. Use only after calling hiddbgAttachHdlsWorkBuffer()
+TransferMemory *hiddbgGetWorkBufferTransferMemoryAddress();
+
 /// Gets state for \ref HiddbgHdlsNpadAssignment. Only available with [7.0.0+].
 Result hiddbgDumpHdlsNpadAssignmentState(HiddbgHdlsNpadAssignment *state);
 

--- a/nx/include/switch/services/hiddbg.h
+++ b/nx/include/switch/services/hiddbg.h
@@ -182,8 +182,8 @@ Result hiddbgAttachHdlsWorkBuffer(void);
 /// Exit Hdls, must be called at some point prior to hiddbgExit. Only available with [7.0.0+].
 Result hiddbgReleaseHdlsWorkBuffer(void);
 
-/// Gets the Tmem pointer. Use only after calling hiddbgAttachHdlsWorkBuffer()
-TransferMemory *hiddbgGetWorkBufferTransferMemoryAddress();
+/// Checks if the given HdlsHandle is still attached, where the result is written to isAttached.  Only available with [7.0.0+].
+Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached);
 
 /// Gets state for \ref HiddbgHdlsNpadAssignment. Only available with [7.0.0+].
 Result hiddbgDumpHdlsNpadAssignmentState(HiddbgHdlsNpadAssignment *state);

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -392,8 +392,7 @@ Result hiddbgReleaseHdlsWorkBuffer(void) {
     return rc;
 }
 
-Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
-{
+Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached) {
     Result rc = 0;
 
     if (hosversionBefore(7,0,0))

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -403,30 +403,22 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
         return MAKERESULT(Module_Libnx, LibnxError_NotInitialized);
 
     rc = _hiddbgCmdNoIO(327);
-    if (R_FAILED(rc))
-        return rc;
-    if (isAttached)
-    {
+    if (R_FAILED(rc)) return rc;
+    if (isAttached) {
 		*isAttached = false;
-        if (hosversionBefore(9, 0, 0))
-        {
+        if (hosversionBefore(9, 0, 0)) {
             HiddbgHdlsStateListV7 *stateList = (HiddbgHdlsStateListV7 *)(g_hiddbgHdlsTmem.src_addr);
-            for (s32 i = 0; i < stateList->total_entries; i++)
-            {
-                if (stateList->entries[i].HdlsHandle == HdlsHandle)
-                {
+            for (s32 i = 0; i < stateList->total_entries; i++) {
+                if (stateList->entries[i].HdlsHandle == HdlsHandle) {
                     *isAttached = true;
                     break;
                 }
             }
         }
-        else
-        {
+        else {
             HiddbgHdlsStateList *stateList = (HiddbgHdlsStateList *)(g_hiddbgHdlsTmem.src_addr);
-            for (s32 i = 0; i < stateList->total_entries; i++)
-            {
-                if (stateList->entries[i].HdlsHandle == HdlsHandle)
-                {
+            for (s32 i = 0; i < stateList->total_entries; i++) {
+                if (stateList->entries[i].HdlsHandle == HdlsHandle) {
                     *isAttached = true;
                     break;
                 }

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -408,7 +408,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
         *isAttached = false;
         if (hosversionBefore(9,0,0)) {
             HiddbgHdlsStateListV7 *stateList = (HiddbgHdlsStateListV7*)(g_hiddbgHdlsTmem.src_addr);
-            for (s32 i = 0; i < stateList->total_entries; i++) {
+            for (s32 i=0; i <stateList->total_entries; i++) {
                 if (stateList->entries[i].HdlsHandle == HdlsHandle) {
                     *isAttached = true;
                     break;
@@ -417,7 +417,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
         }
         else {
             HiddbgHdlsStateList *stateList = (HiddbgHdlsStateList*)(g_hiddbgHdlsTmem.src_addr);
-            for (s32 i = 0; i < stateList->total_entries; i++) {
+            for (s32 i=0; i <stateList->total_entries; i++) {
                 if (stateList->entries[i].HdlsHandle == HdlsHandle) {
                     *isAttached = true;
                     break;

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -392,6 +392,11 @@ Result hiddbgReleaseHdlsWorkBuffer(void) {
     return rc;
 }
 
+TransferMemory *hiddbgGetWorkBufferTransferMemoryAddress()
+{
+	return &g_hiddbgHdlsTmem;
+}
+
 Result hiddbgDumpHdlsNpadAssignmentState(HiddbgHdlsNpadAssignment *state) {
     Result rc=0;
 

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -405,7 +405,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
     rc = _hiddbgCmdNoIO(327);
     if (R_FAILED(rc)) return rc;
     if (isAttached) {
-		*isAttached = false;
+        *isAttached = false;
         if (hosversionBefore(9,0,0)) {
             HiddbgHdlsStateListV7 *stateList = (HiddbgHdlsStateListV7*)(g_hiddbgHdlsTmem.src_addr);
             for (s32 i = 0; i < stateList->total_entries; i++) {

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -407,7 +407,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached) {
         *isAttached = false;
         if (hosversionBefore(9,0,0)) {
             HiddbgHdlsStateListV7 *stateList = (HiddbgHdlsStateListV7*)(g_hiddbgHdlsTmem.src_addr);
-            for (s32 i=0; i <stateList->total_entries; i++) {
+            for (s32 i=0; i<stateList->total_entries; i++) {
                 if (stateList->entries[i].HdlsHandle == HdlsHandle) {
                     *isAttached = true;
                     break;
@@ -416,7 +416,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached) {
         }
         else {
             HiddbgHdlsStateList *stateList = (HiddbgHdlsStateList*)(g_hiddbgHdlsTmem.src_addr);
-            for (s32 i=0; i <stateList->total_entries; i++) {
+            for (s32 i=0; i<stateList->total_entries; i++) {
                 if (stateList->entries[i].HdlsHandle == HdlsHandle) {
                     *isAttached = true;
                     break;

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -396,7 +396,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
 {
     Result rc = 0;
 
-    if (hosversionBefore(7, 0, 0))
+    if (hosversionBefore(7,0,0))
         return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
 
     if (!g_hiddbgHdlsInitialized)
@@ -406,7 +406,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
     if (R_FAILED(rc)) return rc;
     if (isAttached) {
 		*isAttached = false;
-        if (hosversionBefore(9, 0, 0)) {
+        if (hosversionBefore(9,0,0)) {
             HiddbgHdlsStateListV7 *stateList = (HiddbgHdlsStateListV7 *)(g_hiddbgHdlsTmem.src_addr);
             for (s32 i = 0; i < stateList->total_entries; i++) {
                 if (stateList->entries[i].HdlsHandle == HdlsHandle) {

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -407,7 +407,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
     if (isAttached) {
 		*isAttached = false;
         if (hosversionBefore(9,0,0)) {
-            HiddbgHdlsStateListV7 *stateList = (HiddbgHdlsStateListV7 *)(g_hiddbgHdlsTmem.src_addr);
+            HiddbgHdlsStateListV7 *stateList = (HiddbgHdlsStateListV7*)(g_hiddbgHdlsTmem.src_addr);
             for (s32 i = 0; i < stateList->total_entries; i++) {
                 if (stateList->entries[i].HdlsHandle == HdlsHandle) {
                     *isAttached = true;
@@ -416,7 +416,7 @@ Result hiddbgIsHdlsVirtualDeviceAttached(u64 HdlsHandle, bool *isAttached)
             }
         }
         else {
-            HiddbgHdlsStateList *stateList = (HiddbgHdlsStateList *)(g_hiddbgHdlsTmem.src_addr);
+            HiddbgHdlsStateList *stateList = (HiddbgHdlsStateList*)(g_hiddbgHdlsTmem.src_addr);
             for (s32 i = 0; i < stateList->total_entries; i++) {
                 if (stateList->entries[i].HdlsHandle == HdlsHandle) {
                     *isAttached = true;


### PR DESCRIPTION
When low memory usage is important, functions like `hiddbgDumpHdlsStates()` and `hiddbgDumpHdlsNpadAssignmentState()` won't be efficient as they copy the entire struct.
Since there is no need to copy the struct at all, the function `hiddbgGetWorkBufferTransferMemoryAddress()` lets the user read from transfer memory directly.