### PR TITLE
Add support for setting/getting the Internet time sync flag.

### DIFF
--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -212,6 +212,18 @@ Result setsysGetQuestFlag(bool *out);
 Result setsysSetQuestFlag(bool flag);
 
 /**
+ * @brief IsUserSystemClockAutomaticCorrectionEnabled
+ * @param[out] out Output flag.
+ */
+Result setsysIsUserSystemClockAutomaticCorrectionEnabled(bool *out);
+
+/**
+ * @brief SetUserSystemClockAutomaticCorrectionEnabled
+ * @param[in] flag Input flag.
+ */
+Result setsysSetUserSystemClockAutomaticCorrectionEnabled(bool flag);
+
+/**
  * @brief GetUsb30EnableFlag
  * @param[out] out Output flag.
  */

--- a/nx/source/services/set.c
+++ b/nx/source/services/set.c
@@ -289,6 +289,14 @@ Result setsysSetQuestFlag(bool flag) {
     return _setCmdInBoolNoOut(&g_setsysSrv, flag, 48);
 }
 
+Result setsysIsUserSystemClockAutomaticCorrectionEnabled(bool *out) {
+    return _setCmdNoInOutBool(&g_setsysSrv, out, 60);
+}
+
+Result setsysSetUserSystemClockAutomaticCorrectionEnabled(bool flag) {
+    return _setCmdInBoolNoOut(&g_setsysSrv, flag, 61);
+}
+
 Result setsysGetUsb30EnableFlag(bool *out) {
     return _setCmdNoInOutBool(&g_setsysSrv, out, 65);
 }


### PR DESCRIPTION
Adds support for set:sys commmands `IsUserSystemClockAutomaticCorrectionEnabled` and `SetUserSystemClockAutomaticCorrectionEnabled`.

https://switchbrew.org/wiki/Settings_services#set:sys

While I do not have a way to verify that these use `bool`s myself, [SwIPC](https://reswitched.github.io/SwIPC/ifaces.html#nn::settings::ISystemSettingsServer(60)) claims they do, and my own past testing shows that `bools` seem to work fine.