### PR TITLE
Add FsSaveDataFlag for BIT(3)

### DIFF
--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -205,6 +205,7 @@ typedef enum {
     FsSaveDataFlags_KeepAfterResettingSystemSaveData                    = BIT(0),
     FsSaveDataFlags_KeepAfterRefurbishment                              = BIT(1),
     FsSaveDataFlags_KeepAfterResettingSystemSaveDataWithoutUserSaveData = BIT(2),
+    FsSaveDataFlags_NeedsSecureDelete                                   = BIT(3),
 } FsSaveDataFlags;
 
 typedef enum {


### PR DESCRIPTION
ref https://github.com/Thealexbarney/LibHac/blob/f3b5cad94b1d0ce5a1799048172f99e5fd7c3f59/src/LibHac/FsService/FileSystemProxy.cs#L178

in testing, present in the following saves in 9.0.1:
```
save id              flags owner id
8000000000000010     1100  010000000000001e
8000000000000050     1000  0100000000000009
80000000000000a0     1000  010000000000000c
80000000000000a1     1000  010000000000000c
80000000000000a2     1000  010000000000000c
8000000000000190     1000  0100000000000031
```
makes sense for account, settings, prepo saves (not sure why glue)