### PR TITLE
applet: use _appletCleanup instead of appletExit in _appletExitProcess

### DIFF
--- a/nx/source/services/applet.c
+++ b/nx/source/services/applet.c
@@ -334,7 +334,7 @@ static void _appletInfiniteSleepLoop(void) {
 }
 
 static void NORETURN _appletExitProcess(int result_code) {
-    appletExit();
+    _appletCleanup();
 
     if (R_SUCCEEDED(g_appletExitProcessResult)) _appletInfiniteSleepLoop();
 


### PR DESCRIPTION
The service guard prevented appletExit from being called multiple times, so call _appletCleanup instead.  
This fixes exit when `(envIsNso() && __nx_applet_exit_mode==0) || __nx_applet_exit_mode==1`.