### PR TITLE
Update documentation about fsdevMountDevice() to inform about trailing colons in device names.

### DIFF
--- a/nx/include/switch/runtime/devices/fs_dev.h
+++ b/nx/include/switch/runtime/devices/fs_dev.h
@@ -38,6 +38,7 @@ Result fsdevMountSystemSaveData(const char *name, FsSaveDataSpaceId save_data_sp
 
 /// Mounts the input fs with the specified device name. fsdev will handle closing the fs when required, including when fsdevMountDevice() fails.
 /// Returns -1 when any errors occur.
+/// Input device name string shouldn't exceed 31 characters, and shouldn't have a trailing colon.
 int fsdevMountDevice(const char *name, FsFileSystem fs);
 
 /// Unmounts the specified device.

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -315,7 +315,12 @@ static int _fsdevMountDevice(const char *name, FsFileSystem fs, fsdev_fsdevice *
 
   device->fs = fs;
   memset(device->name, 0, sizeof(device->name));
-  strncpy(device->name, name, sizeof(device->name)-1);
+  
+  size_t devnamelen = strlen(name);
+  if (devnamelen > (sizeof(device->name) - 1)) devnamelen = (sizeof(device->name) - 1); // Truncate the device name if it's too long
+  if (name[devnamelen - 1] == ':') devnamelen--; // Make sure we don't copy a trailing colon if it was provided
+  
+  strncpy(device->name, name, devnamelen);
 
   int dev = AddDevice(&device->device);
   if(dev==-1)

--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -315,12 +315,7 @@ static int _fsdevMountDevice(const char *name, FsFileSystem fs, fsdev_fsdevice *
 
   device->fs = fs;
   memset(device->name, 0, sizeof(device->name));
-  
-  size_t devnamelen = strlen(name);
-  if (devnamelen > (sizeof(device->name) - 1)) devnamelen = (sizeof(device->name) - 1); // Truncate the device name if it's too long
-  if (name[devnamelen - 1] == ':') devnamelen--; // Make sure we don't copy a trailing colon if it was provided
-  
-  strncpy(device->name, name, devnamelen);
+  strncpy(device->name, name, sizeof(device->name)-1);
 
   int dev = AddDevice(&device->device);
   if(dev==-1)


### PR DESCRIPTION
Fixes fsdev_fixpath() returning NULL when a FsFileSystem object is mounted using a device name with a trailing colon.