### PR TITLE
ts: Add temperature location comments

### DIFF
--- a/nx/include/switch/services/ts.h
+++ b/nx/include/switch/services/ts.h
@@ -10,8 +10,8 @@
 
 /// Location
 typedef enum {
-    TsLocation_Internal = 0,    ///< Internal
-    TsLocation_External = 1,    ///< External
+    TsLocation_Internal = 0,    ///< TMP451 Internal: PCB
+    TsLocation_External = 1,    ///< TMP451 External: SoC
 } TsLocation;
 
 /// Initialize ts.


### PR DESCRIPTION
Avert some confusion about the temperature locations.
HOS uses TMP451 IC's internal thermistor for PCB temp readings
External is connected to a thermistor to SoC's package temp pins, so SoC temp readings.