### PR TITLE
hid: Update the value for JOYSTICK_MIN

### DIFF
--- a/nx/include/switch/services/hid.h
+++ b/nx/include/switch/services/hid.h
@@ -431,7 +431,7 @@ typedef struct SixAxisSensorValues {
 } SixAxisSensorValues;
 
 #define JOYSTICK_MAX (0x7FFF)
-#define JOYSTICK_MIN (-0x8000)
+#define JOYSTICK_MIN (-0x7FFF)
 
 // End enums and output structs
 


### PR DESCRIPTION
I know you guys have changed JOYSTICK_MAX in one of the commits (b83ddf8157e7aef37159aaff9e0b40b137339504) after getting complaints in the IRC chat. There is more to this problem, where games like Resident Evil 4 and (i think) Assassin's Creed 3 make assertions on joystick values being at least -32767 and at most 32767 and aborting if it's outside the range of acceptable values. I'm guesing they take those values from the SDK so the values in libnx should be updated accordingly.