### PR TITLE
add lstat to fs_dev and romfs_dev

### DIFF
--- a/nx/source/runtime/devices/fs_dev.c
+++ b/nx/source/runtime/devices/fs_dev.c
@@ -90,6 +90,8 @@ fsdev_devoptab =
   .chmod_r      = fsdev_chmod,
   .fchmod_r     = fsdev_fchmod,
   .rmdir_r      = fsdev_rmdir,
+  // symlinks aren't supported so alias lstat to stat
+  .lstat_r      = fsdev_stat,
 };
 
 typedef struct

--- a/nx/source/runtime/devices/romfs_dev.c
+++ b/nx/source/runtime/devices/romfs_dev.c
@@ -168,6 +168,8 @@ static const devoptab_t romFS_devoptab =
     .dirreset_r   = romfs_dirreset,
     .dirnext_r    = romfs_dirnext,
     .dirclose_r   = romfs_dirclose,
+    // symlinks aren't supported so alias lstat to stat
+    .lstat_r      = romfs_stat,
 };
 
 static bool romfs_initialised = false;


### PR DESCRIPTION
lstat is supported by devoptab, but we don't expose it
symlinks aren't a thing on fat32/exfat so we can just alias lstat to stat.