### PR TITLE
hiddbg: implement DeactivateHomeButton

### DIFF
--- a/nx/include/switch/services/hiddbg.h
+++ b/nx/include/switch/services/hiddbg.h
@@ -121,6 +121,9 @@ void hiddbgExit(void);
 /// Gets the Service object for the actual hiddbg service session.
 Service* hiddbgGetServiceSession(void);
 
+/// Ignores subsequent home button presses.
+Result hiddbgDeactivateHomeButton(void);
+
 /// Writes the input RGB colors to the spi-flash for the specified controller (offset 0x6050 size 0x6). See hidsys.h for UniquePadId. Only available with [3.0.0+].
 Result hiddbgUpdateControllerColor(u32 colorBody, u32 colorButtons, u64 UniquePadId);
 

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -76,6 +76,10 @@ static Result _hiddbgCmdInTmemNoOut(TransferMemory *tmem, u32 cmd_id) {
     return _hiddbgCmdInHandle64NoOut(tmem->handle, tmem->size, cmd_id);
 }
 
+Result hiddbgDeactivateHomeButton(void) {
+    return _hiddbgCmdNoIO(110);
+}
+
 Result hiddbgUpdateControllerColor(u32 colorBody, u32 colorButtons, u64 UniquePadId) {
     if (hosversionBefore(3,0,0))
         return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);


### PR DESCRIPTION
This is needed to prevent home button presses when running system updater homebrew from applet mode.