### PR TITLE
docs: fix simple typo, recieve -> receive

### DIFF
--- a/nx/include/switch/runtime/devices/socket.h
+++ b/nx/include/switch/runtime/devices/socket.h
@@ -13,7 +13,7 @@ typedef struct  {
     u32 bsdsockets_version;                     ///< Observed 1 on 2.0 LibAppletWeb, 2 on 3.0.
 
     u32 tcp_tx_buf_size;                        ///< Size of the TCP transfer (send) buffer (initial or fixed).
-    u32 tcp_rx_buf_size;                        ///< Size of the TCP recieve buffer (initial or fixed).
+    u32 tcp_rx_buf_size;                        ///< Size of the TCP receive buffer (initial or fixed).
     u32 tcp_tx_buf_max_size;                    ///< Maximum size of the TCP transfer (send) buffer. If it is 0, the size of the buffer is fixed to its initial value.
     u32 tcp_rx_buf_max_size;                    ///< Maximum size of the TCP receive buffer. If it is 0, the size of the buffer is fixed to its initial value.
 

--- a/nx/include/switch/services/bsd.h
+++ b/nx/include/switch/services/bsd.h
@@ -19,7 +19,7 @@ typedef struct  {
     u32 version;                ///< Observed 1 on [2.0.0+] LibAppletWeb, 2 on [3.0.0+].
 
     u32 tcp_tx_buf_size;        ///< Size of the TCP transfer (send) buffer (initial or fixed).
-    u32 tcp_rx_buf_size;        ///< Size of the TCP recieve buffer (initial or fixed).
+    u32 tcp_rx_buf_size;        ///< Size of the TCP receive buffer (initial or fixed).
     u32 tcp_tx_buf_max_size;    ///< Maximum size of the TCP transfer (send) buffer. If it is 0, the size of the buffer is fixed to its initial value.
     u32 tcp_rx_buf_max_size;    ///< Maximum size of the TCP receive buffer. If it is 0, the size of the buffer is fixed to its initial value.
 


### PR DESCRIPTION
There is a small typo in nx/include/switch/runtime/devices/socket.h, nx/include/switch/services/bsd.h.

Should read `receive` rather than `recieve`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md