### PR TITLE
fs: Added fsCreateSaveDataFileSystem(), fsDeleteSaveDataFileSystem() and fsDeleteSaveDataFileSystemBySaveDataAttribute().

### DIFF
--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -88,12 +88,12 @@ typedef struct {
     u8 unused[0x190];               ///< Uninitialized.
 } FsSaveDataExtraData;
 
-/// FsSaveMeta
+/// SaveDataMetaInfo
 typedef struct {
-    u32 meta_file_size;
-    u8 meta_index;
-    u8 unk[0x0B];
-} FsSaveMeta;
+    u32 size;
+    u8 type;                        ///< \ref FsSaveDataMetaType
+    u8 reserved[0x0B];
+} FsSaveDataMetaInfo;
 
 /// SaveDataCreationInfo
 typedef struct {
@@ -226,6 +226,13 @@ typedef enum {
     FsSaveDataFlags_NeedsSecureDelete                                   = BIT(3),
 } FsSaveDataFlags;
 
+/// SaveDataMetaType
+typedef enum {
+    FsSaveDataMetaType_None             = 0,
+    FsSaveDataMetaType_Thumbnail        = 1,
+    FsSaveDataMetaType_ExtensionContext = 2,
+} FsSaveDataMetaType;
+
 typedef enum {
     FsGameCardAttribute_AutoBootFlag                          = BIT(0), ///< Causes the cartridge to automatically start on bootup
     FsGameCardAttribute_HistoryEraseFlag                      = BIT(1), ///< Causes NS to throw an error on attempt to load the cartridge
@@ -331,7 +338,7 @@ Result fsOpenBisStorage(FsStorage* out, FsBisPartitionId partitionId);
 Result fsOpenSdCardFileSystem(FsFileSystem* out);
 
 Result fsDeleteSaveDataFileSystem(u64 application_id);
-Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info, const FsSaveMeta* meta);
+Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info, const FsSaveDataMetaInfo* meta);
 Result fsCreateSaveDataFileSystemBySystemSaveDataId(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info);
 Result fsDeleteSaveDataFileSystemBySaveDataSpaceId(FsSaveDataSpaceId save_data_space_id, u64 saveID); ///< [2.0.0+]
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -341,6 +341,7 @@ Result fsDeleteSaveDataFileSystem(u64 application_id);
 Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info, const FsSaveDataMetaInfo* meta);
 Result fsCreateSaveDataFileSystemBySystemSaveDataId(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info);
 Result fsDeleteSaveDataFileSystemBySaveDataSpaceId(FsSaveDataSpaceId save_data_space_id, u64 saveID); ///< [2.0.0+]
+Result fsDeleteSaveDataFileSystemBySaveDataAttribute(FsSaveDataSpaceId save_data_space_id, const FsSaveDataAttribute* attr); ///< [4.0.0+]
 
 Result fsIsExFatSupported(bool* out);
 

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -88,6 +88,13 @@ typedef struct {
     u8 unused[0x190];               ///< Uninitialized.
 } FsSaveDataExtraData;
 
+/// FsSaveMeta
+typedef struct {
+    u32 meta_file_size;
+    u8 meta_index;
+    u8 unk[0x0B];
+} FsSaveMeta;
+
 /// SaveDataCreationInfo
 typedef struct {
     s64 save_data_size;    ///< Size of the save data.
@@ -323,6 +330,8 @@ Result fsOpenBisStorage(FsStorage* out, FsBisPartitionId partitionId);
 /// Do not call this directly, see fs_dev.h.
 Result fsOpenSdCardFileSystem(FsFileSystem* out);
 
+Result fsDeleteSaveDataFileSystem(u64 application_id);
+Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info, const FsSaveMeta* meta);
 Result fsCreateSaveDataFileSystemBySystemSaveDataId(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info);
 Result fsDeleteSaveDataFileSystemBySaveDataSpaceId(FsSaveDataSpaceId save_data_space_id, u64 saveID); ///< [2.0.0+]
 

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -225,11 +225,7 @@ Result fsOpenSdCardFileSystem(FsFileSystem* out) {
 }
 
 Result fsDeleteSaveDataFileSystem(u64 application_id) {
-    const struct {
-        u64 application_id;
-    } in = { application_id };
-
-    return _fsObjectDispatchIn(&g_fsSrv, 21, in);
+    return _fsObjectDispatchIn(&g_fsSrv, 21, application_id);
 }
 
 Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info, const FsSaveMeta* meta) {

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -228,11 +228,11 @@ Result fsDeleteSaveDataFileSystem(u64 application_id) {
     return _fsObjectDispatchIn(&g_fsSrv, 21, application_id);
 }
 
-Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info, const FsSaveMeta* meta) {
+Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info, const FsSaveDataMetaInfo* meta) {
     const struct {
         FsSaveDataAttribute attr;
         FsSaveDataCreationInfo creation_info;
-        FsSaveMeta meta;
+        FsSaveDataMetaInfo meta;
     } in = { *attr, *creation_info, *meta };
 
     return _fsObjectDispatchIn(&g_fsSrv, 22, in);

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -224,6 +224,24 @@ Result fsOpenSdCardFileSystem(FsFileSystem* out) {
     return _fsCmdGetSession(&g_fsSrv, &out->s, 18);
 }
 
+Result fsDeleteSaveDataFileSystem(u64 application_id) {
+    const struct {
+        u64 application_id;
+    } in = { application_id };
+
+    return _fsObjectDispatchIn(&g_fsSrv, 21, in);
+}
+
+Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info, const FsSaveMeta* meta) {
+    const struct {
+        FsSaveDataAttribute attr;
+        FsSaveDataCreationInfo creation_info;
+		FsSaveMeta meta;
+    } in = { *attr, *creation_info, *meta };
+
+    return _fsObjectDispatchIn(&g_fsSrv, 22, in);
+}
+
 Result fsCreateSaveDataFileSystemBySystemSaveDataId(const FsSaveDataAttribute* attr, const FsSaveDataCreationInfo* creation_info) {
     const struct {
         FsSaveDataAttribute attr;

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -259,6 +259,18 @@ Result fsDeleteSaveDataFileSystemBySaveDataSpaceId(FsSaveDataSpaceId save_data_s
     return _fsObjectDispatchIn(&g_fsSrv, 25, in);
 }
 
+Result fsDeleteSaveDataFileSystemBySaveDataAttribute(FsSaveDataSpaceId save_data_space_id, const FsSaveDataAttribute* attr) {
+    if (hosversionBefore(4,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    const struct {
+        u8 save_data_space_id;
+        FsSaveDataAttribute attr;
+    } in = { (u8)save_data_space_id, *attr };
+
+    return _fsObjectDispatchIn(&g_fsSrv, 28, in);
+}
+
 Result fsIsExFatSupported(bool* out) {
     if (hosversionBefore(2,0,0)) {
         *out = false;

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -236,7 +236,7 @@ Result fsCreateSaveDataFileSystem(const FsSaveDataAttribute* attr, const FsSaveD
     const struct {
         FsSaveDataAttribute attr;
         FsSaveDataCreationInfo creation_info;
-		FsSaveMeta meta;
+        FsSaveMeta meta;
     } in = { *attr, *creation_info, *meta };
 
     return _fsObjectDispatchIn(&g_fsSrv, 22, in);


### PR DESCRIPTION
These are needed to easily generate custom `FsSaveDataType_Cache` savedata entries.

Unlike normal savedata, cache savedata size can't be retrieved from the NACP, which means it's necessary to calculate its required size. One could then create a cache savedata entry larger than the calculated size, which is simpler than having to resize the existent save each time new data is written to it.