### PR TITLE
psc: fix dependency argument on init

### DIFF
--- a/nx/include/switch/services/psc.h
+++ b/nx/include/switch/services/psc.h
@@ -94,7 +94,7 @@ void pscmExit(void);
 /// Gets the Service object for the actual psc:m service session.
 Service* pscmGetServiceSession(void);
 
-Result pscmGetPmModule(PscPmModule *out, PscPmModuleId module_id, const u16 *dependencies, size_t dependency_count, bool autoclear);
+Result pscmGetPmModule(PscPmModule *out, PscPmModuleId module_id, const u32 *dependencies, size_t dependency_count, bool autoclear);
 
 Result pscPmModuleGetRequest(PscPmModule *module, PscPmState *out_state, u32 *out_flags);
 Result pscPmModuleAcknowledge(PscPmModule *module, PscPmState state);

--- a/nx/source/services/psc.c
+++ b/nx/source/services/psc.c
@@ -25,9 +25,9 @@ Service* pscmGetServiceSession(void) {
 }
 
 
-NX_INLINE Result _pscPmModuleInitialize(PscPmModule *module, PscPmModuleId module_id, const u16 *dependencies, size_t dependency_count, bool autoclear);
+NX_INLINE Result _pscPmModuleInitialize(PscPmModule *module, PscPmModuleId module_id, const u32 *dependencies, size_t dependency_count, bool autoclear);
 
-Result pscmGetPmModule(PscPmModule *out, PscPmModuleId module_id, const u16 *dependencies, size_t dependency_count, bool autoclear) {
+Result pscmGetPmModule(PscPmModule *out, PscPmModuleId module_id, const u32 *dependencies, size_t dependency_count, bool autoclear) {
     serviceAssumeDomain(&g_pscmSrv);
     Result rc = serviceDispatch(&g_pscmSrv, 0,
         .out_num_objects = 1,
@@ -43,7 +43,7 @@ Result pscmGetPmModule(PscPmModule *out, PscPmModuleId module_id, const u16 *dep
     return rc;
 }
 
-Result _pscPmModuleInitialize(PscPmModule *module, PscPmModuleId module_id, const u16 *dependencies, size_t dependency_count, bool autoclear) {
+Result _pscPmModuleInitialize(PscPmModule *module, PscPmModuleId module_id, const u32 *dependencies, size_t dependency_count, bool autoclear) {
     _Static_assert(sizeof(module_id) == sizeof(u32), "PscPmModuleId size");
 
     Handle evt_handle = INVALID_HANDLE;


### PR DESCRIPTION
whoops, this was actually u32 the whole time (it's PmModuleIds).