### PR TITLE
btdrv: improve and update event data definitions for 12.0.0, misc other minor changes

### DIFF
--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -492,14 +492,21 @@ Result btdrvRemoveBond(BtdrvAddress addr);
 Result btdrvCancelBond(BtdrvAddress addr);
 
 /**
- * @brief RespondToPinRequest
+ * @brief RespondToPinRequest [1.0.0-11.0.1]
  * @note The official sysmodule only uses the input \ref BtdrvAddress.
  * @param[in] addr \ref BtdrvAddress
  * @param[in] flag Flag
  * @param[in] pin_code \ref BtdrvBluetoothPinCode
  * @param[in] length Length of pin_code
  */
-Result btdrvRespondToPinRequest(BtdrvAddress addr, bool flag, const BtdrvBluetoothPinCode *pin_code, u8 length);
+Result btdrvLegacyRespondToPinRequest(BtdrvAddress addr, bool flag, const BtdrvBluetoothPinCode *pin_code, u8 length);
+
+/**
+ * @brief RespondToPinRequest [12.0.0+]
+ * @param[in] addr \ref BtdrvAddress
+ * @param[in] pin_code \ref BtdrvPinCode
+ */
+Result btdrvRespondToPinRequest(BtdrvAddress addr, const BtdrvPinCode *pin_code);
 
 /**
  * @brief RespondToSspRequest

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -106,6 +106,35 @@ typedef struct {
         } connection;                    ///< ::BtdrvEventType_Connection
 
         struct {
+            BtdrvAddress addr;           ///< Device address.
+            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
+            u8 value;                    ///< Tsi value, when the above indicates success.
+        } tsi;                           ///< ::BtdrvEventType_Tsi
+
+        struct {
+            BtdrvAddress addr;           ///< Device address.
+            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
+            u8 value;                    ///< Input bool value from \ref btdrvEnableBurstMode, when the above indicates success.
+        } burst_mode;                    ///< ::BtdrvEventType_BurstMode
+
+        struct {
+            BtdrvAddress addr;           ///< Device address.
+            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
+            u8 flag;                     ///< Bool flag, when the above indicates success.
+        } set_zero_retransmission;       ///< ::BtdrvEventType_SetZeroRetransmission
+
+        struct {
+            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
+            u8 pad[0x3];                 ///< Padding
+            u32 count;                   ///< Count value.
+        } pending_connections;           ///< ::BtdrvEventType_PendingConnections
+
+        struct {
+            BtdrvAddress addr;           ///< Device address.
+            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
+        } move_to_secondary_piconet;     ///< ::BtdrvEventType_MoveToSecondaryPiconet
+
+        struct {
             u16 reason;                  ///< \ref BtdrvFatalReason
         } bluetooth_crash;               ///< ::BtdrvEventType_BluetoothCrash
     };

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -80,12 +80,11 @@ typedef struct {
                     BtdrvAddress addr;                      ///< Device address.
                     char name[0xF9];                        ///< Device name, NUL-terminated string.
                     BtdrvClassOfDevice class_of_device;     ///< Class of Device.
-                    u32 type;                               ///< 0 = SSP confirm request, 3 = SSP passkey notification.
+                    u8 flag;                                ///< bool flag for Just Works. With SSP passkey notification this is always 0
                     u8 pad;                                 ///< Padding
                     s32 passkey;                            ///< Passkey, only set when the above field is value 3.
                 } v12;  ///< [12.0.0+]
             };  
-            
         } ssp_request;                              ///< ::BtdrvEventType_SspRequest
 
         struct {

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -52,7 +52,7 @@ typedef struct {
                 } v1;                                       ///< [1.0.0-11.0.1]
 
                 struct {
-                    BtdrvInquiryStatus status;              ///< \ref BtdrvInquiryStatus
+                    u8 status;                              ///< Status: 0 = stopped, 1 = started.
                     u8 pad[3];                              ///< Padding
                     u32 service_mask;                       ///< Services value from \ref btdrvStartInquiry when starting, otherwise this is value 0
                 } v12;                                      ///< [12.0.0+]

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -14,11 +14,11 @@
 /// Data for \ref btdrvGetEventInfo. The data stored here depends on the \ref BtdrvEventType.
 typedef struct {
     union {
-        u8 data[0x400];                  ///< Raw data.
+        u8 data[0x400];                                     ///< Raw data.
 
         struct {
-            u32 val;                     ///< Value
-        } type0;                         ///< ::BtdrvEventType_Unknown0
+            u32 val;                                        ///< Value
+        } type0;                                            ///< ::BtdrvEventType_Unknown0
 
         struct {
             union {
@@ -34,36 +34,36 @@ typedef struct {
                     u8 rssi[0x4];                           ///< s32 RSSI
                     u8 name3[0x4];                          ///< Two bytes which are the same as name[11-12].
                     u8 reserved_x36D[0x10];                 ///< Reserved
-                } v1;   ///< [1.0.0-11.0.1]
+                } v1;                                       ///< [1.0.0-11.0.1]
 
                 struct {
                     BtdrvAddress addr;                      ///< Device address.
                     char name[0xF9];                        ///< Device name, NUL-terminated string.
                     BtdrvClassOfDevice class_of_device;     ///< Class of Device.
                     u8 reserved[0x6];                       ///< Reserved
-                } v12;  ///< [12.0.0+]
+                } v12;                                      ///< [12.0.0+]
             };
         } inquiry_device;                                   ///< ::BtdrvEventType_InquiryDevice
 
         struct {
             union {
                 struct {
-                    BtdrvInquiryStatus status;      ///< Status: 0 = stopped, 1 = started.
-                } v1;   ///< [1.0.0-11.0.1]
+                    BtdrvInquiryStatus status;              ///< Status: 0 = stopped, 1 = started.
+                } v1;                                       ///< [1.0.0-11.0.1]
 
                 struct {
-                    BtdrvInquiryStatus status;      ///< Status: 0 = stopped, 1 = started.
-                    u8 pad[3];                      ///< Padding
-                    u32 service_mask;               ///< Services value from /ref btdrvStartInquiry when starting, otherwise this is value 0
-                } v12;  ///< [12.0.0+]
+                    BtdrvInquiryStatus status;              ///< Status: 0 = stopped, 1 = started.
+                    u8 pad[3];                              ///< Padding
+                    u32 service_mask;                       ///< Services value from /ref btdrvStartInquiry when starting, otherwise this is value 0
+                } v12;                                      ///< [12.0.0+]
             };
-        } inquiry_status;                           ///< ::BtdrvEventType_InquiryStatus
+        } inquiry_status;                                   ///< ::BtdrvEventType_InquiryStatus
 
         struct {
-            BtdrvAddress addr;                      ///< Device address.
-            char name[0xF9];                        ///< Device name, NUL-terminated string.
-            BtdrvClassOfDevice class_of_device;     ///< Class of Device.
-        } pairing_pin_code_request;                 ///< ::BtdrvEventType_PairingPinCodeRequest
+            BtdrvAddress addr;                              ///< Device address.
+            char name[0xF9];                                ///< Device name, NUL-terminated string.
+            BtdrvClassOfDevice class_of_device;             ///< Class of Device.
+        } pairing_pin_code_request;                         ///< ::BtdrvEventType_PairingPinCodeRequest
 
         struct {
             union {
@@ -74,7 +74,7 @@ typedef struct {
                     u8 pad[2];                              ///< Padding
                     u32 type;                               ///< 0 = SSP confirm request, 3 = SSP passkey notification.
                     s32 passkey;                            ///< Passkey, only set when the above field is value 3.
-                } v1;   ///< [1.0.0-11.0.1]
+                } v1;                                       ///< [1.0.0-11.0.1]
 
                 struct {
                     BtdrvAddress addr;                      ///< Device address.
@@ -83,133 +83,133 @@ typedef struct {
                     u8 flag;                                ///< bool flag for Just Works. With SSP passkey notification this is always 0
                     u8 pad;                                 ///< Padding
                     s32 passkey;                            ///< Passkey, only set when the above field is value 3.
-                } v12;  ///< [12.0.0+]
+                } v12;                                      ///< [12.0.0+]
             };  
-        } ssp_request;                              ///< ::BtdrvEventType_SspRequest
+        } ssp_request;                                      ///< ::BtdrvEventType_SspRequest
 
         struct {
             union {
                 struct {
-                    u32 status;                  ///< Status, always 0 except with ::BtdrvConnectionEventType_Status: 2 = ACL Link is now Resumed, 9 = connection failed (pairing/authentication failed, or opening the hid connection failed).
-                    BtdrvAddress addr;           ///< Device address.
-                    u8 pad[2];                   ///< Padding
-                    u32 type;                    ///< \ref BtdrvConnectionEventType
-                } v1;   ///< [1.0.0-11.0.1]
+                    u32 status;                             ///< Status, always 0 except with ::BtdrvConnectionEventType_Status: 2 = ACL Link is now Resumed, 9 = connection failed (pairing/authentication failed, or opening the hid connection failed).
+                    BtdrvAddress addr;                      ///< Device address.
+                    u8 pad[2];                              ///< Padding
+                    u32 type;                               ///< \ref BtdrvConnectionEventType
+                } v1;                                       ///< [1.0.0-11.0.1]
 
                 struct {
-                    u32 type;                   ///< \ref BtdrvConnectionEventType
-                    BtdrvAddress addr;          ///< Device address.
-                    u8 reserved[0xfe];          ///< Reserved
-                } v12;  ///< [12.0.0+]
+                    u32 type;                               ///< \ref BtdrvConnectionEventType
+                    BtdrvAddress addr;                      ///< Device address.
+                    u8 reserved[0xfe];                      ///< Reserved
+                } v12;                                      ///< [12.0.0+]
             };
-        } connection;                    ///< ::BtdrvEventType_Connection
+        } connection;                                       ///< ::BtdrvEventType_Connection
 
         struct {
-            BtdrvAddress addr;           ///< Device address.
-            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
-            u8 value;                    ///< Tsi value, when the above indicates success.
-        } tsi;                           ///< ::BtdrvEventType_Tsi
+            BtdrvAddress addr;                              ///< Device address.
+            u8 status;                                      ///< Status flag: 1 = success, 0 = failure.
+            u8 value;                                       ///< Tsi value, when the above indicates success.
+        } tsi;                                              ///< ::BtdrvEventType_Tsi
 
         struct {
-            BtdrvAddress addr;           ///< Device address.
-            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
-            u8 value;                    ///< Input bool value from \ref btdrvEnableBurstMode, when the above indicates success.
-        } burst_mode;                    ///< ::BtdrvEventType_BurstMode
+            BtdrvAddress addr;                              ///< Device address.
+            u8 status;                                      ///< Status flag: 1 = success, 0 = failure.
+            u8 value;                                       ///< Input bool value from \ref btdrvEnableBurstMode, when the above indicates success.
+        } burst_mode;                                       ///< ::BtdrvEventType_BurstMode
 
         struct {
-            BtdrvAddress addr;           ///< Device address.
-            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
-            u8 flag;                     ///< Bool flag, when the above indicates success.
-        } set_zero_retransmission;       ///< ::BtdrvEventType_SetZeroRetransmission
+            BtdrvAddress addr;                              ///< Device address.
+            u8 status;                                      ///< Status flag: 1 = success, 0 = failure.
+            u8 flag;                                        ///< Bool flag, when the above indicates success.
+        } set_zero_retransmission;                          ///< ::BtdrvEventType_SetZeroRetransmission
 
         struct {
-            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
-            u8 pad[0x3];                 ///< Padding
-            u32 count;                   ///< Count value.
-        } pending_connections;           ///< ::BtdrvEventType_PendingConnections
+            u8 status;                                      ///< Status flag: 1 = success, 0 = failure.
+            u8 pad[0x3];                                    ///< Padding
+            u32 count;                                      ///< Count value.
+        } pending_connections;                              ///< ::BtdrvEventType_PendingConnections
 
         struct {
-            BtdrvAddress addr;           ///< Device address.
-            u8 status;                   ///< Status flag: 1 = success, 0 = failure.
-        } move_to_secondary_piconet;     ///< ::BtdrvEventType_MoveToSecondaryPiconet
+            BtdrvAddress addr;                              ///< Device address.
+            u8 status;                                      ///< Status flag: 1 = success, 0 = failure.
+        } move_to_secondary_piconet;                        ///< ::BtdrvEventType_MoveToSecondaryPiconet
 
         struct {
-            u16 reason;                  ///< \ref BtdrvFatalReason
-        } bluetooth_crash;               ///< ::BtdrvEventType_BluetoothCrash
+            u16 reason;                                     ///< \ref BtdrvFatalReason
+        } bluetooth_crash;                                  ///< ::BtdrvEventType_BluetoothCrash
     };
 } BtdrvEventInfo;
 
 /// Data for \ref btdrvGetHidEventInfo. The data stored here depends on the \ref BtdrvHidEventType.
 typedef struct {
     union {
-        u8 data[0x480];                  ///< Raw data.
+        u8 data[0x480];                                 ///< Raw data.
 
         struct {
             union {
                 struct {
-                    BtdrvAddress addr;                    ///< Device address.
-                    u8 pad[2];                            ///< Padding
-                    BtdrvHidConnectionStatus status;      ///< \ref BtdrvHidConnectionStatus
+                    BtdrvAddress addr;                  ///< Device address.
+                    u8 pad[2];                          ///< Padding
+                    BtdrvHidConnectionStatus status;    ///< \ref BtdrvHidConnectionStatus
                 } v1;   ///< [1.0.0-11.0.1]
 
                 struct {
-                    BtdrvHidConnectionStatus status;      ///< \ref BtdrvHidConnectionStatus
-                    BtdrvAddress addr;                    ///< Device address.
+                    BtdrvHidConnectionStatus status;    ///< \ref BtdrvHidConnectionStatus
+                    BtdrvAddress addr;                  ///< Device address.
                 } v12;  ///< [12.0.0+]
             };
-        } connection;                             ///< ::BtdrvHidEventType_Connection
+        } connection;                                   ///< ::BtdrvHidEventType_Connection
 
         struct {
-            u32 type;                             ///< \ref BtdrvExtEventType, controls which data is stored below.
+            u32 type;                                   ///< \ref BtdrvExtEventType, controls which data is stored below.
 
             union {
                 struct {
-                    u32 status;                   ///< 0 for success, non-zero for error.
-                    BtdrvAddress addr;            ///< Device address.
-                } set_tsi;                        ///< ::BtdrvExtEventType_SetTsi
+                    u32 status;                         ///< 0 for success, non-zero for error.
+                    BtdrvAddress addr;                  ///< Device address.
+                } set_tsi;                              ///< ::BtdrvExtEventType_SetTsi
 
                 struct {
-                    u32 status;                   ///< 0 for success, non-zero for error.
-                    BtdrvAddress addr;            ///< Device address.
-                } exit_tsi;                       ///< ::BtdrvExtEventType_ExitTsi
+                    u32 status;                         ///< 0 for success, non-zero for error.
+                    BtdrvAddress addr;                  ///< Device address.
+                } exit_tsi;                             ///< ::BtdrvExtEventType_ExitTsi
 
                 struct {
-                    u32 status;                   ///< 0 for success, non-zero for error.
-                    BtdrvAddress addr;            ///< Device address.
-                } set_burst_mode;                 ///< ::BtdrvExtEventType_SetBurstMode
+                    u32 status;                         ///< 0 for success, non-zero for error.
+                    BtdrvAddress addr;                  ///< Device address.
+                } set_burst_mode;                       ///< ::BtdrvExtEventType_SetBurstMode
 
                 struct {
-                    u32 status;                   ///< 0 for success, non-zero for error.
-                    BtdrvAddress addr;            ///< Device address.
-                } exit_burst_mode;                ///< ::BtdrvExtEventType_ExitBurstMode
+                    u32 status;                         ///< 0 for success, non-zero for error.
+                    BtdrvAddress addr;                  ///< Device address.
+                } exit_burst_mode;                      ///< ::BtdrvExtEventType_ExitBurstMode
 
                 struct {
-                    u32 status;                   ///< 0 for success, non-zero for error.
-                    BtdrvAddress addr;            ///< Device address.
-                    u8 pad[2];                    ///< Padding
-                    u8 flag;                      ///< Flag
-                } set_zero_retransmission;        ///< ::BtdrvExtEventType_SetZeroRetransmission
+                    u32 status;                         ///< 0 for success, non-zero for error.
+                    BtdrvAddress addr;                  ///< Device address.
+                    u8 pad[2];                          ///< Padding
+                    u8 flag;                            ///< Flag
+                } set_zero_retransmission;              ///< ::BtdrvExtEventType_SetZeroRetransmission
 
                 struct {
-                    u32 status;                   ///< 0 for success, non-zero for error.
-                    BtdrvAddress addr;            ///< Unused
-                    u8 pad[2];                    ///< Padding
-                    u32 count;                    ///< Count value.
-                } pending_connections;            ///< ::BtdrvExtEventType_PendingConnections
+                    u32 status;                         ///< 0 for success, non-zero for error.
+                    BtdrvAddress addr;                  ///< Unused
+                    u8 pad[2];                          ///< Padding
+                    u32 count;                          ///< Count value.
+                } pending_connections;                  ///< ::BtdrvExtEventType_PendingConnections
 
                 struct {
-                    u32 status;                   ///< 0 for success, non-zero for error.
-                    BtdrvAddress addr;            ///< Device address.
-                } move_to_secondary_piconet;      ///< ::BtdrvExtEventType_MoveToSecondaryPiconet
+                    u32 status;                         ///< 0 for success, non-zero for error.
+                    BtdrvAddress addr;                  ///< Device address.
+                } move_to_secondary_piconet;            ///< ::BtdrvExtEventType_MoveToSecondaryPiconet
             };
-        } ext;                                    ///< ::BtdrvHidEventType_Ext [1.0.0-11.0.1]
+        } ext;                                          ///< ::BtdrvHidEventType_Ext [1.0.0-11.0.1]
     };
 } BtdrvHidEventInfo;
 
 /// Data for \ref btdrvGetHidReportEventInfo. The data stored here depends on the \ref BtdrvHidEventType.
 typedef struct {
     union {
-        u8 data[0x480];                  ///< Raw data.
+        u8 data[0x480];                         ///< Raw data.
 
         struct {
             union {
@@ -220,73 +220,73 @@ typedef struct {
                         u32 res;
                         u32 size;
                     } hdr;
-                    u8 unused[0x3];                  ///< Unused
-                    BtdrvAddress addr;               ///< \ref BtdrvAddress
-                    u8 unused2[0x3];                 ///< Unused
+                    u8 unused[0x3];             ///< Unused
+                    BtdrvAddress addr;          ///< \ref BtdrvAddress
+                    u8 unused2[0x3];            ///< Unused
                     BtdrvHidData report;
-                } v1;                                ///< [1.0.0-6.2.0]
+                } v1;                           ///< [1.0.0-6.2.0]
 
                 struct {
-                    u8 unused[0x3];                  ///< Unused
-                    BtdrvAddress addr;               ///< \ref BtdrvAddress
-                    u8 unused2[0x3];                 ///< Unused
+                    u8 unused[0x3];             ///< Unused
+                    BtdrvAddress addr;          ///< \ref BtdrvAddress
+                    u8 unused2[0x3];            ///< Unused
                     BtdrvHidData report;
-                } v7;                                ///< [7.0.0-8.1.1]
+                } v7;                           ///< [7.0.0-8.1.1]
 
                 struct {
-                    u32 res;                         ///< Always 0.
-                    u8 unk_x4;                       ///< Always 0.
-                    BtdrvAddress addr;               ///< \ref BtdrvAddress
-                    u8 pad;                          ///< Padding
+                    u32 res;                    ///< Always 0.
+                    u8 unk_x4;                  ///< Always 0.
+                    BtdrvAddress addr;          ///< \ref BtdrvAddress
+                    u8 pad;                     ///< Padding
                     BtdrvHidReport report;
-                } v9;                                ///< [9.0.0+]
+                } v9;                           ///< [9.0.0+]
             };
-        } data_report;                           ///< ::BtdrvHidEventType_DataReport
+        } data_report;                          ///< ::BtdrvHidEventType_DataReport
 
         struct {
             union {
-                u8 rawdata[0xC];                 ///< Raw data.
+                u8 rawdata[0xC];                ///< Raw data.
 
                 struct {
-                    u32 res;                     ///< 0 = success, non-zero = error.
-                    BtdrvAddress addr;           ///< \ref BtdrvAddress
-                    u8 pad[2];                   ///< Padding
+                    u32 res;                    ///< 0 = success, non-zero = error.
+                    BtdrvAddress addr;          ///< \ref BtdrvAddress
+                    u8 pad[2];                  ///< Padding
                 };
             };
-        } set_report;                            ///< ::BtdrvHidEventType_SetReport
+        } set_report;                           ///< ::BtdrvHidEventType_SetReport
 
         struct {
             union {
                 union {
-                    u8 rawdata[0x290];           ///< Raw data.
+                    u8 rawdata[0x290];          ///< Raw data.
 
                     struct {
-                        BtdrvAddress addr;       ///< \ref BtdrvAddress
-                        u8 pad[2];               ///< Padding
-                        u32 res;                 ///< Unknown. hid-sysmodule only uses the below data when this field is 0.
-                        BtdrvHidData report;     ///< \ref BtdrvHidData
-                        u8 pad2[2];              ///< Padding
+                        BtdrvAddress addr;      ///< \ref BtdrvAddress
+                        u8 pad[2];              ///< Padding
+                        u32 res;                ///< Unknown. hid-sysmodule only uses the below data when this field is 0.
+                        BtdrvHidData report;    ///< \ref BtdrvHidData
+                        u8 pad2[2];             ///< Padding
                     };
-                } v1;                            ///< [1.0.0-8.1.1]
+                } v1;                           ///< [1.0.0-8.1.1]
 
                 union {
-                    u8 rawdata[0x2C8];           ///< Raw data.
+                    u8 rawdata[0x2C8];          ///< Raw data.
 
                     struct {
-                        u32 res;                 ///< Unknown. hid-sysmodule only uses the below report when this field is 0.
-                        BtdrvAddress addr;       ///< \ref BtdrvAddress
-                        BtdrvHidReport report;   ///< \ref BtdrvHidReport
+                        u32 res;                ///< Unknown. hid-sysmodule only uses the below report when this field is 0.
+                        BtdrvAddress addr;      ///< \ref BtdrvAddress
+                        BtdrvHidReport report;  ///< \ref BtdrvHidReport
                     };
-                } v9;                            ///< [9.0.0+]
+                } v9;                           ///< [9.0.0+]
             };
-        } get_report;                            ///< ::BtdrvHidEventType_GetReport
+        } get_report;                           ///< ::BtdrvHidEventType_GetReport
     };
 } BtdrvHidReportEventInfo;
 
 /// The raw sharedmem data for HidReportEventInfo.
 typedef struct {
     struct {
-        u8 type;                                 ///< \ref BtdrvHidEventType
+        u8 type;        ///< \ref BtdrvHidEventType
         u8 pad[7];
         u64 tick;
         u64 size;
@@ -298,7 +298,7 @@ typedef struct {
 /// CircularBuffer
 typedef struct {
     Mutex mutex;
-    void* event_type;          ///< Not set with sharedmem.
+    void* event_type;   ///< Not set with sharedmem.
     u8 data[0x2710];
     s32 write_offset;
     s32 read_offset;

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -34,14 +34,14 @@ typedef struct {
                     u8 rssi[0x4];                           ///< s32 RSSI
                     u8 name3[0x4];                          ///< Two bytes which are the same as name[11-12].
                     u8 reserved_x36D[0x10];                 ///< Reserved
-                } v1;
+                } v1;   ///< [1.0.0-11.0.1]
 
                 struct {
                     BtdrvAddress addr;                      ///< Device address.
                     char name[0xF9];                        ///< Device name, NUL-terminated string.
                     BtdrvClassOfDevice class_of_device;     ///< Class of Device.
                     u8 reserved[0x6];                       ///< Reserved
-                } v12;
+                } v12;  ///< [12.0.0+]
             };
         } inquiry_device;                                   ///< ::BtdrvEventType_InquiryDevice
 
@@ -49,13 +49,13 @@ typedef struct {
             union {
                 struct {
                     BtdrvInquiryStatus status;      ///< Status: 0 = stopped, 1 = started.
-                } v1;
+                } v1;   ///< [1.0.0-11.0.1]
 
                 struct {
                     BtdrvInquiryStatus status;      ///< Status: 0 = stopped, 1 = started.
                     u8 pad[3];                      ///< Padding
                     u32 service_mask;               ///< Services value from /ref btdrvStartInquiry when starting, otherwise this is value 0
-                } v12;
+                } v12;  ///< [12.0.0+]
             };
         } inquiry_status;                           ///< ::BtdrvEventType_InquiryStatus
 
@@ -74,7 +74,7 @@ typedef struct {
                     u8 pad[2];                              ///< Padding
                     u32 type;                               ///< 0 = SSP confirm request, 3 = SSP passkey notification.
                     s32 passkey;                            ///< Passkey, only set when the above field is value 3.
-                } v1;
+                } v1;   ///< [1.0.0-11.0.1]
 
                 struct {
                     BtdrvAddress addr;                      ///< Device address.
@@ -83,8 +83,8 @@ typedef struct {
                     u32 type;                               ///< 0 = SSP confirm request, 3 = SSP passkey notification.
                     u8 pad;                                 ///< Padding
                     s32 passkey;                            ///< Passkey, only set when the above field is value 3.
-                } v12;
-            };
+                } v12;  ///< [12.0.0+]
+            };  
             
         } ssp_request;                              ///< ::BtdrvEventType_SspRequest
 
@@ -95,13 +95,13 @@ typedef struct {
                     BtdrvAddress addr;           ///< Device address.
                     u8 pad[2];                   ///< Padding
                     u32 type;                    ///< \ref BtdrvConnectionEventType
-                } v1;
+                } v1;   ///< [1.0.0-11.0.1]
 
                 struct {
                     u32 type;                   ///< \ref BtdrvConnectionEventType
                     BtdrvAddress addr;          ///< Device address.
                     u8 reserved[0xfe];          ///< Reserved
-                } v12;
+                } v12;  ///< [12.0.0+]
             };
         } connection;                    ///< ::BtdrvEventType_Connection
 
@@ -151,12 +151,12 @@ typedef struct {
                     BtdrvAddress addr;                    ///< Device address.
                     u8 pad[2];                            ///< Padding
                     BtdrvHidConnectionStatus status;      ///< Status: 0 = hid connection opened, 2 = hid connection closed, 8 = failed to open hid connection.
-                } v1;
+                } v1;   ///< [1.0.0-11.0.1]
 
                 struct {
                     BtdrvHidConnectionStatus status;      ///< Status: 1 = hid connection opened, 0 = hid connection closed
                     BtdrvAddress addr;                    ///< Device address.
-                } v12;
+                } v12;  ///< [12.0.0+]
             };
         } connection;                             ///< ::BtdrvHidEventType_Connection
 
@@ -225,14 +225,14 @@ typedef struct {
                     BtdrvAddress addr;               ///< \ref BtdrvAddress
                     u8 unused2[0x3];                 ///< Unused
                     BtdrvHidData report;
-                } v1;                                ///< Pre-7.0.0
+                } v1;                                ///< [1.0.0-6.2.0]
 
                 struct {
                     u8 unused[0x3];                  ///< Unused
                     BtdrvAddress addr;               ///< \ref BtdrvAddress
                     u8 unused2[0x3];                 ///< Unused
                     BtdrvHidData report;
-                } v7;                                ///< Pre-9.0.0
+                } v7;                                ///< [7.0.0-8.1.1]
 
                 struct {
                     u32 res;                         ///< Always 0.
@@ -268,7 +268,7 @@ typedef struct {
                         BtdrvHidData report;     ///< \ref BtdrvHidData
                         u8 pad2[2];              ///< Padding
                     };
-                } v1;                            ///< Pre-9.0.0
+                } v1;                            ///< [1.0.0-8.1.1]
 
                 union {
                     u8 rawdata[0x2C8];           ///< Raw data.

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -1,7 +1,7 @@
 /**
  * @file btdrv.h
  * @brief Bluetooth driver (btdrv) service IPC wrapper.
- * @author yellows8
+ * @author yellows8, ndeadly
  * @copyright libnx Authors
  */
 #pragma once
@@ -40,7 +40,7 @@ typedef struct {
                     BtdrvAddress addr;                      ///< Device address.
                     char name[0xF9];                        ///< Device name, NUL-terminated string.
                     BtdrvClassOfDevice class_of_device;     ///< Class of Device.
-                    u8 reserved[0x6];
+                    u8 reserved[0x6];                       ///< Reserved
                 } v12;
             };
         } inquiry_device;                                   ///< ::BtdrvEventType_InquiryDevice
@@ -54,7 +54,7 @@ typedef struct {
                 struct {
                     BtdrvInquiryStatus status;      ///< Status: 0 = stopped, 1 = started.
                     u8 pad[3];                      ///< Padding
-                    u32 service_mask;
+                    u32 service_mask;               ///< Services value from /ref btdrvStartInquiry when starting, otherwise this is value 0
                 } v12;
             };
         } inquiry_status;                           ///< ::BtdrvEventType_InquiryStatus
@@ -98,9 +98,9 @@ typedef struct {
                 } v1;
 
                 struct {
-                    u32 type;                    ///< \ref BtdrvConnectionEventType
-                    BtdrvAddress addr;           ///< Device address.
-                    u8 reserved[0xfe];
+                    u32 type;                   ///< \ref BtdrvConnectionEventType
+                    BtdrvAddress addr;          ///< Device address.
+                    u8 reserved[0xfe];          ///< Reserved
                 } v12;
             };
         } connection;                    ///< ::BtdrvEventType_Connection
@@ -154,7 +154,7 @@ typedef struct {
                 } v1;
 
                 struct {
-                    BtdrvHidConnectionStatusV12 status;      ///< Status: 0 = hid connection opened, 2 = hid connection closed, 8 = failed to open hid connection.
+                    BtdrvHidConnectionStatus status;      ///< Status: 1 = hid connection opened, 0 = hid connection closed
                     BtdrvAddress addr;                    ///< Device address.
                 } v12;
             };
@@ -203,7 +203,7 @@ typedef struct {
                     BtdrvAddress addr;            ///< Device address.
                 } move_to_secondary_piconet;      ///< ::BtdrvExtEventType_MoveToSecondaryPiconet
             };
-        } ext;                                    ///< ::BtdrvHidEventType_Ext
+        } ext;                                    ///< ::BtdrvHidEventType_Ext [1.0.0-11.0.1]
     };
 } BtdrvHidEventInfo;
 
@@ -217,7 +217,7 @@ typedef struct {
                 struct {
                     struct {
                         BtdrvAddress addr;
-                        u8 pad[2]; // Todo: check if padding used here
+                        u8 pad[2];
                         u32 res;
                         u32 size;
                     } hdr;
@@ -235,7 +235,7 @@ typedef struct {
                 } v7;                                ///< Pre-9.0.0
 
                 struct {
-                    u32 res;                         //< Always 0.
+                    u32 res;                         ///< Always 0.
                     u8 unk_x4;                       ///< Always 0.
                     BtdrvAddress addr;               ///< \ref BtdrvAddress
                     u8 pad;                          ///< Padding

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -436,32 +436,60 @@ Result btdrvDisableBluetooth(void);
 Result btdrvFinalizeBluetooth(void);
 
 /**
- * @brief GetAdapterProperties
- * @param[out] property \ref BtdrvAdapterProperty
+ * @brief GetAdapterProperties [1.0.0-11.0.1]
+ * @param[out] properties \ref BtdrvAdapterProperty
  */
-Result btdrvGetAdapterProperties(BtdrvAdapterProperty *property);
+Result btdrvLegacyGetAdapterProperties(BtdrvAdapterPropertyOld *properties);
 
 /**
- * @brief GetAdapterProperty
+ * @brief GetAdapterProperties [12.0.0+]
+ * @param[out] properties \ref BtdrvAdapterPropertySet
+ */
+Result btdrvGetAdapterProperties(BtdrvAdapterPropertySet *properties);
+
+/**
+ * @brief GetAdapterProperty [1.0.0-11.0.1]
  * @param[in] type \ref BtdrvBluetoothPropertyType
  * @param[out] buffer Output buffer, see \ref BtdrvBluetoothPropertyType for the contents.
  * @param[in] size Output buffer size.
  */
-Result btdrvGetAdapterProperty(BtdrvBluetoothPropertyType type, void* buffer, size_t size);
+Result btdrvLegacyGetAdapterProperty(BtdrvBluetoothPropertyType type, void* buffer, size_t size);
 
 /**
- * @brief SetAdapterProperty
+ * @brief GetAdapterProperty [12.0.0+]
+ * @param[in] type \ref BtdrvAdapterPropertyType
+ * @param[in] property \ref BtdrvAdapterProperty
+ */
+Result btdrvGetAdapterProperty(BtdrvAdapterPropertyType type, BtdrvAdapterProperty *property);
+
+/**
+ * @brief SetAdapterProperty [1.0.0-11.0.1]
  * @param[in] type \ref BtdrvBluetoothPropertyType
  * @param[in] buffer Input buffer, see \ref BtdrvBluetoothPropertyType for the contents.
  * @param[in] size Input buffer size.
  */
-Result btdrvSetAdapterProperty(BtdrvBluetoothPropertyType type, const void* buffer, size_t size);
+Result btdrvLegacySetAdapterProperty(BtdrvBluetoothPropertyType type, const void* buffer, size_t size);
 
 /**
- * @brief This starts Inquiry, the output data will be available via \ref btdrvGetEventInfo. Inquiry will automatically stop in 10.24 seconds.
+ * @brief SetAdapterProperty [12.0.0+]
+ * @param[in] type \ref BtdrvAdapterPropertyType
+ * @param[in] property \ref BtdrvAdapterProperty
+ */
+Result btdrvSetAdapterProperty(BtdrvAdapterPropertyType type, const BtdrvAdapterProperty *property);
+
+/**
+ * @brief StartInquiry [1.0.0-11.0.1] This starts Inquiry, the output data will be available via \ref btdrvGetEventInfo. Inquiry will automatically stop in 10.24 seconds.
  * @note This is used by btm-sysmodule.
  */
-Result btdrvStartInquiry(void);
+Result btdrvLegacyStartInquiry(void);
+
+/**
+ * @brief [12.0.0+] This starts Inquiry, the output data will be available via \ref btdrvGetEventInfo.
+ * @param[in] services Bitmask of allowed services. When -1 the original defaults from pre-12.0.0 are used.
+ * @param[in] duration Inquiry duration in nanoseconds.
+ * @note This is used by btm-sysmodule.
+ */
+Result btdrvStartInquiry(u32 services, s64 duration);
 
 /**
  * @brief This stops Inquiry which was started by \ref btdrvStartInquiry, if it's still active.
@@ -514,17 +542,17 @@ Result btdrvRespondToPinRequest(BtdrvAddress addr, const BtdrvPinCode *pin_code)
  * @note This is used by btm-sysmodule.
  * @param[in] addr \ref BtdrvAddress
  * @param[in] variant BluetoothSspVariant
- * @param[in] flag Whether the request is accepted.
- * @param[in] unk Unknown
+ * @param[in] accept Whether the request is accepted.
+ * @param[in] passkey Passkey.
  */
-Result btdrvRespondToSspRequest(BtdrvAddress addr, u8 variant, bool flag, u32 unk);
+Result btdrvRespondToSspRequest(BtdrvAddress addr, u8 variant, bool accept, u32 passkey);
 
 /**
  * @brief GetEventInfo
  * @note This is used by btm-sysmodule.
  * @param[out] buffer Output buffer, see \ref BtdrvEventInfo.
  * @param[in] size Output buffer size.
- * @oaram[out] type Output BtdrvEventType.
+ * @param[out] type Output BtdrvEventType.
  */
 Result btdrvGetEventInfo(void* buffer, size_t size, BtdrvEventType *type);
 

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -150,11 +150,11 @@ typedef struct {
                 struct {
                     BtdrvAddress addr;                    ///< Device address.
                     u8 pad[2];                            ///< Padding
-                    BtdrvHidConnectionStatus status;      ///< Status: 0 = hid connection opened, 2 = hid connection closed, 8 = failed to open hid connection.
+                    BtdrvHidConnectionStatus status;      ///< \ref BtdrvHidConnectionStatus
                 } v1;   ///< [1.0.0-11.0.1]
 
                 struct {
-                    BtdrvHidConnectionStatus status;      ///< Status: 1 = hid connection opened, 0 = hid connection closed
+                    BtdrvHidConnectionStatus status;      ///< \ref BtdrvHidConnectionStatus
                     BtdrvAddress addr;                    ///< Device address.
                 } v12;  ///< [12.0.0+]
             };

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -484,7 +484,7 @@ Result btdrvSetAdapterProperty(BtdrvAdapterPropertyType type, const BtdrvAdapter
 Result btdrvLegacyStartInquiry(void);
 
 /**
- * @brief [12.0.0+] This starts Inquiry, the output data will be available via \ref btdrvGetEventInfo.
+ * @brief StartInquiry [12.0.0+] This starts Inquiry, the output data will be available via \ref btdrvGetEventInfo.
  * @param[in] services Bitmask of allowed services. When -1 the original defaults from pre-12.0.0 are used.
  * @param[in] duration Inquiry duration in nanoseconds.
  * @note This is used by btm-sysmodule.

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -21,22 +21,43 @@ typedef struct {
         } type0;                         ///< ::BtdrvEventType_Unknown0
 
         struct {
-            char name[0xF9];                        ///< Device name, NUL-terminated string.
-            BtdrvAddress addr;                      ///< Device address.
-            u8 reserved_xFF[0x10];                  ///< Reserved
-            BtdrvClassOfDevice class_of_device;     ///< Class of Device.
-            u8 unk_x112[0x4];                       ///< Set to fixed value u32 0x1.
-            u8 reserved_x116[0xFA];                 ///< Reserved
-            u8 reserved_x210[0x5C];                 ///< Reserved
-            char name2[0xF9];                       ///< Device name, NUL-terminated string. Same as name above, except starting at index 1.
-            u8 rssi[0x4];                           ///< s32 RSSI
-            u8 name3[0x4];                          ///< Two bytes which are the same as name[11-12].
-            u8 reserved_x36D[0x10];                 ///< Reserved
-        } inquiry_device;                           ///< ::BtdrvEventType_InquiryDevice
+            union {
+                struct {
+                    char name[0xF9];                        ///< Device name, NUL-terminated string.
+                    BtdrvAddress addr;                      ///< Device address.
+                    u8 reserved_xFF[0x10];                  ///< Reserved
+                    BtdrvClassOfDevice class_of_device;     ///< Class of Device.
+                    u8 unk_x112[0x4];                       ///< Set to fixed value u32 0x1.
+                    u8 reserved_x116[0xFA];                 ///< Reserved
+                    u8 reserved_x210[0x5C];                 ///< Reserved
+                    char name2[0xF9];                       ///< Device name, NUL-terminated string. Same as name above, except starting at index 1.
+                    u8 rssi[0x4];                           ///< s32 RSSI
+                    u8 name3[0x4];                          ///< Two bytes which are the same as name[11-12].
+                    u8 reserved_x36D[0x10];                 ///< Reserved
+                } v1;
+
+                struct {
+                    BtdrvAddress addr;                      ///< Device address.
+                    char name[0xF9];                        ///< Device name, NUL-terminated string.
+                    BtdrvClassOfDevice class_of_device;     ///< Class of Device.
+                    u8 reserved[0x6];
+                } v12;
+            };
+        } inquiry_device;                                   ///< ::BtdrvEventType_InquiryDevice
 
         struct {
-            BtdrvInquiryStatus status;   ///< Status: 0 = stopped, 1 = started.
-        } inquiry_status;                ///< ::BtdrvEventType_InquiryStatus
+            union {
+                struct {
+                    BtdrvInquiryStatus status;      ///< Status: 0 = stopped, 1 = started.
+                } v1;
+
+                struct {
+                    BtdrvInquiryStatus status;      ///< Status: 0 = stopped, 1 = started.
+                    u8 pad[3];                      ///< Padding
+                    u32 service_mask;
+                } v12;
+            };
+        } inquiry_status;                           ///< ::BtdrvEventType_InquiryStatus
 
         struct {
             BtdrvAddress addr;                      ///< Device address.
@@ -45,19 +66,43 @@ typedef struct {
         } pairing_pin_code_request;                 ///< ::BtdrvEventType_PairingPinCodeRequest
 
         struct {
-            BtdrvAddress addr;                      ///< Device address.
-            char name[0xF9];                        ///< Device name, NUL-terminated string.
-            BtdrvClassOfDevice class_of_device;     ///< Class of Device.
-            u8 pad[2];                              ///< Padding
-            u32 type;                               ///< 0 = SSP confirm request, 3 = SSP passkey notification.
-            s32 passkey;                            ///< Passkey, only set when the above field is value 3.
+            union {
+                struct {
+                    BtdrvAddress addr;                      ///< Device address.
+                    char name[0xF9];                        ///< Device name, NUL-terminated string.
+                    BtdrvClassOfDevice class_of_device;     ///< Class of Device.
+                    u8 pad[2];                              ///< Padding
+                    u32 type;                               ///< 0 = SSP confirm request, 3 = SSP passkey notification.
+                    s32 passkey;                            ///< Passkey, only set when the above field is value 3.
+                } v1;
+
+                struct {
+                    BtdrvAddress addr;                      ///< Device address.
+                    char name[0xF9];                        ///< Device name, NUL-terminated string.
+                    BtdrvClassOfDevice class_of_device;     ///< Class of Device.
+                    u32 type;                               ///< 0 = SSP confirm request, 3 = SSP passkey notification.
+                    u8 pad;                                 ///< Padding
+                    s32 passkey;                            ///< Passkey, only set when the above field is value 3.
+                } v12;
+            };
+            
         } ssp_request;                              ///< ::BtdrvEventType_SspRequest
 
         struct {
-            u32 status;                  ///< Status, always 0 except with ::BtdrvConnectionEventType_Status: 2 = ACL Link is now Resumed, 9 = connection failed (pairing/authentication failed, or opening the hid connection failed).
-            BtdrvAddress addr;           ///< Device address.
-            u8 pad[2];                   ///< Padding
-            u32 type;                    ///< \ref BtdrvConnectionEventType
+            union {
+                struct {
+                    u32 status;                  ///< Status, always 0 except with ::BtdrvConnectionEventType_Status: 2 = ACL Link is now Resumed, 9 = connection failed (pairing/authentication failed, or opening the hid connection failed).
+                    BtdrvAddress addr;           ///< Device address.
+                    u8 pad[2];                   ///< Padding
+                    u32 type;                    ///< \ref BtdrvConnectionEventType
+                } v1;
+
+                struct {
+                    u32 type;                    ///< \ref BtdrvConnectionEventType
+                    BtdrvAddress addr;           ///< Device address.
+                    u8 reserved[0xfe];
+                } v12;
+            };
         } connection;                    ///< ::BtdrvEventType_Connection
 
         struct {
@@ -72,9 +117,18 @@ typedef struct {
         u8 data[0x480];                  ///< Raw data.
 
         struct {
-            BtdrvAddress addr;                    ///< Device address.
-            u8 pad[2];                            ///< Padding
-            BtdrvHidConnectionStatus status;      ///< Status: 0 = hid connection opened, 2 = hid connection closed, 8 = failed to open hid connection.
+            union {
+                struct {
+                    BtdrvAddress addr;                    ///< Device address.
+                    u8 pad[2];                            ///< Padding
+                    BtdrvHidConnectionStatus status;      ///< Status: 0 = hid connection opened, 2 = hid connection closed, 8 = failed to open hid connection.
+                } v1;
+
+                struct {
+                    BtdrvHidConnectionStatusV12 status;      ///< Status: 0 = hid connection opened, 2 = hid connection closed, 8 = failed to open hid connection.
+                    BtdrvAddress addr;                    ///< Device address.
+                } v12;
+            };
         } connection;                             ///< ::BtdrvHidEventType_Connection
 
         struct {
@@ -415,9 +469,9 @@ Result btdrvCancelBond(BtdrvAddress addr);
  * @param[in] addr \ref BtdrvAddress
  * @param[in] flag Flag
  * @param[in] pin_code \ref BtdrvBluetoothPinCode
- * @param[in] unk Unknown
+ * @param[in] length Length of pin_code
  */
-Result btdrvRespondToPinRequest(BtdrvAddress addr, bool flag, const BtdrvBluetoothPinCode *pin_code, u8 unk);
+Result btdrvRespondToPinRequest(BtdrvAddress addr, bool flag, const BtdrvBluetoothPinCode *pin_code, u8 length);
 
 /**
  * @brief RespondToSspRequest

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -54,7 +54,7 @@ typedef struct {
                 struct {
                     BtdrvInquiryStatus status;              ///< \ref BtdrvInquiryStatus
                     u8 pad[3];                              ///< Padding
-                    u32 service_mask;                       ///< Services value from /ref btdrvStartInquiry when starting, otherwise this is value 0
+                    u32 service_mask;                       ///< Services value from \ref btdrvStartInquiry when starting, otherwise this is value 0
                 } v12;                                      ///< [12.0.0+]
             };
         } inquiry_status;                                   ///< ::BtdrvEventType_InquiryStatus

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -331,7 +331,7 @@ typedef struct {
             u16 max_interval;
             u16 slave_latency;
             u16 timeout_multiplier;
-        } type3; // Connection params
+        } type3;                                ///< Connection params?
 
         struct {
             u32 status;
@@ -342,7 +342,7 @@ typedef struct {
             u32 conn_id;
             BtdrvAddress address;
             u16 unk_x12;
-        } type4; // Connection status
+        } type4;                                ///< Connection status?
 
         struct {
             u32 status;
@@ -353,7 +353,7 @@ typedef struct {
             BtdrvBleAdvertisementData adv[10];
             u8 count;
             u32 unk_x144;
-        } type6; // Scan result
+        } type6;                                ///< Scan result?
 
         struct {
             u32 status;
@@ -371,7 +371,7 @@ typedef struct {
             BtdrvGattAttributeUuid descr_uuid;
             u16 size;
             u8 data[0x202];
-        } type8; // Notification
+        } type8;                                ///< Notification?
 
         struct {
             u32 status;

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -82,7 +82,7 @@ typedef struct {
                     BtdrvClassOfDevice class_of_device;     ///< Class of Device.
                     u8 flag;                                ///< bool flag for Just Works. With SSP passkey notification this is always 0
                     u8 pad;                                 ///< Padding
-                    s32 passkey;                            ///< Passkey, only set when the above field is value 3.
+                    s32 passkey;                            ///< Passkey
                 } v12;                                      ///< [12.0.0+]
             };  
         } ssp_request;                                      ///< ::BtdrvEventType_SspRequest

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -316,7 +316,7 @@ typedef struct {
         struct {
             u32 status;
             u8 handle;
-            bool registered;
+            u8 registered;
         } type0;
 
         struct {

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -52,7 +52,7 @@ typedef struct {
                 } v1;                                       ///< [1.0.0-11.0.1]
 
                 struct {
-                    u8 status;                              ///< Status: 0 = stopped, 1 = started.
+                    u8 status;                              ///< \ref BtdrvInquiryStatus
                     u8 pad[3];                              ///< Padding
                     u32 service_mask;                       ///< Services value from \ref btdrvStartInquiry when starting, otherwise this is value 0
                 } v12;                                      ///< [12.0.0+]

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -48,11 +48,11 @@ typedef struct {
         struct {
             union {
                 struct {
-                    BtdrvInquiryStatus status;              ///< Status: 0 = stopped, 1 = started.
+                    BtdrvInquiryStatus status;              ///< \ref BtdrvInquiryStatus
                 } v1;                                       ///< [1.0.0-11.0.1]
 
                 struct {
-                    BtdrvInquiryStatus status;              ///< Status: 0 = stopped, 1 = started.
+                    BtdrvInquiryStatus status;              ///< \ref BtdrvInquiryStatus
                     u8 pad[3];                              ///< Padding
                     u32 service_mask;                       ///< Services value from /ref btdrvStartInquiry when starting, otherwise this is value 0
                 } v12;                                      ///< [12.0.0+]

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -150,12 +150,12 @@ typedef struct {
                     BtdrvAddress addr;                  ///< Device address.
                     u8 pad[2];                          ///< Padding
                     BtdrvHidConnectionStatus status;    ///< \ref BtdrvHidConnectionStatus
-                } v1;   ///< [1.0.0-11.0.1]
+                } v1;                                   ///< [1.0.0-11.0.1]
 
                 struct {
                     BtdrvHidConnectionStatus status;    ///< \ref BtdrvHidConnectionStatus
                     BtdrvAddress addr;                  ///< Device address.
-                } v12;  ///< [12.0.0+]
+                } v12;                                  ///< [12.0.0+]
             };
         } connection;                                   ///< ::BtdrvHidEventType_Connection
 

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -21,37 +21,37 @@ typedef struct {
         } type0;                         ///< ::BtdrvEventType_Unknown0
 
         struct {
-            u8 name[0xF9];               ///< Device name, NUL-terminated string.
-            BtdrvAddress addr;           ///< Device address.
-            u8 reserved_xFF[0x10];       ///< Reserved
-            u8 class_of_device[0x3];     ///< Class of Device.
-            u8 unk_x112[0x4];            ///< Set to fixed value u32 0x1.
-            u8 reserved_x116[0xFA];      ///< Reserved
-            u8 reserved_x210[0x5C];      ///< Reserved
-            u8 name2[0xF9];              ///< Device name, NUL-terminated string. Same as name above, except starting at index 1.
-            u8 rssi[0x4];                ///< s32 RSSI
-            u8 name3[0x4];               ///< Two bytes which are the same as name[11-12].
-            u8 reserved_x36D[0x10];      ///< Reserved
-        } inquiry_device;                ///< ::BtdrvEventType_InquiryDevice
+            char name[0xF9];                        ///< Device name, NUL-terminated string.
+            BtdrvAddress addr;                      ///< Device address.
+            u8 reserved_xFF[0x10];                  ///< Reserved
+            BtdrvClassOfDevice class_of_device;     ///< Class of Device.
+            u8 unk_x112[0x4];                       ///< Set to fixed value u32 0x1.
+            u8 reserved_x116[0xFA];                 ///< Reserved
+            u8 reserved_x210[0x5C];                 ///< Reserved
+            char name2[0xF9];                       ///< Device name, NUL-terminated string. Same as name above, except starting at index 1.
+            u8 rssi[0x4];                           ///< s32 RSSI
+            u8 name3[0x4];                          ///< Two bytes which are the same as name[11-12].
+            u8 reserved_x36D[0x10];                 ///< Reserved
+        } inquiry_device;                           ///< ::BtdrvEventType_InquiryDevice
 
         struct {
-            u32 status;                  ///< Status: 0 = stopped, 1 = started.
+            BtdrvInquiryStatus status;   ///< Status: 0 = stopped, 1 = started.
         } inquiry_status;                ///< ::BtdrvEventType_InquiryStatus
 
         struct {
-            BtdrvAddress addr;           ///< Device address.
-            u8 name[0xF9];               ///< Device name, NUL-terminated string.
-            u8 class_of_device[0x3];     ///< Class of Device.
-        } pairing_pin_code_request;      ///< ::BtdrvEventType_PairingPinCodeRequest
+            BtdrvAddress addr;                      ///< Device address.
+            char name[0xF9];                        ///< Device name, NUL-terminated string.
+            BtdrvClassOfDevice class_of_device;     ///< Class of Device.
+        } pairing_pin_code_request;                 ///< ::BtdrvEventType_PairingPinCodeRequest
 
         struct {
-            BtdrvAddress addr;           ///< Device address.
-            u8 name[0xF9];               ///< Device name, NUL-terminated string.
-            u8 class_of_device[0x3];     ///< Class of Device.
-            u8 pad[2];                   ///< Padding
-            u32 type;                    ///< 0 = SSP confirm request, 3 = SSP passkey notification.
-            s32 passkey;                 ///< Passkey, only set when the above field is value 3.
-        } ssp_request;                   ///< ::BtdrvEventType_SspRequest
+            BtdrvAddress addr;                      ///< Device address.
+            char name[0xF9];                        ///< Device name, NUL-terminated string.
+            BtdrvClassOfDevice class_of_device;     ///< Class of Device.
+            u8 pad[2];                              ///< Padding
+            u32 type;                               ///< 0 = SSP confirm request, 3 = SSP passkey notification.
+            s32 passkey;                            ///< Passkey, only set when the above field is value 3.
+        } ssp_request;                              ///< ::BtdrvEventType_SspRequest
 
         struct {
             u32 status;                  ///< Status, always 0 except with ::BtdrvConnectionEventType_Status: 2 = ACL Link is now Resumed, 9 = connection failed (pairing/authentication failed, or opening the hid connection failed).
@@ -72,10 +72,10 @@ typedef struct {
         u8 data[0x480];                  ///< Raw data.
 
         struct {
-            BtdrvAddress addr;           ///< Device address.
-            u8 pad[2];                   ///< Padding
-            u32 status;                  ///< Status: 0 = hid connection opened, 2 = hid connection closed, 8 = failed to open hid connection.
-        } connection;                    ///< ::BtdrvHidEventType_Connection
+            BtdrvAddress addr;                    ///< Device address.
+            u8 pad[2];                            ///< Padding
+            BtdrvHidConnectionStatus status;      ///< Status: 0 = hid connection opened, 2 = hid connection closed, 8 = failed to open hid connection.
+        } connection;                             ///< ::BtdrvHidEventType_Connection
 
         struct {
             u32 type;                             ///< \ref BtdrvExtEventType, controls which data is stored below.
@@ -130,25 +130,48 @@ typedef struct {
         u8 data[0x480];                  ///< Raw data.
 
         struct {
-            u32 unk_x0;                  ///< Always 0.
-            u8 unk_x4;                   ///< Always 0.
-            BtdrvAddress addr;           ///< \ref BtdrvAddress
-            u8 pad;                      ///< Padding
-            u16 size;                    ///< Size of the below data.
-            u8 data[];                   ///< Data.
-        } data_report;                   ///< ::BtdrvHidEventType_Data
+            union {
+                struct {
+                    struct {
+                        BtdrvAddress addr;
+                        u8 pad[2]; // Todo: check if padding used here
+                        u32 res;
+                        u32 size;
+                    } hdr;
+                    u8 unused[0x3];                  ///< Unused
+                    BtdrvAddress addr;               ///< \ref BtdrvAddress
+                    u8 unused2[0x3];                 ///< Unused
+                    BtdrvHidData report;
+                } v1;                                ///< Pre-7.0.0
+
+                struct {
+                    u8 unused[0x3];                  ///< Unused
+                    BtdrvAddress addr;               ///< \ref BtdrvAddress
+                    u8 unused2[0x3];                 ///< Unused
+                    BtdrvHidData report;
+                } v7;                                ///< Pre-9.0.0
+
+                struct {
+                    u32 res;                         //< Always 0.
+                    u8 unk_x4;                       ///< Always 0.
+                    BtdrvAddress addr;               ///< \ref BtdrvAddress
+                    u8 pad;                          ///< Padding
+                    BtdrvHidReport report;
+                } v9;                                ///< [9.0.0+]
+            };
+        } data_report;                           ///< ::BtdrvHidEventType_DataReport
 
         struct {
             union {
-                u8 data[0xC];                ///< Raw data.
+                u8 rawdata[0xC];                 ///< Raw data.
 
                 struct {
-                    u32 res;                 ///< 0 = success, non-zero = error.
-                    BtdrvAddress addr;       ///< \ref BtdrvAddress
-                    u8 pad[2];               ///< Padding
+                    u32 res;                     ///< 0 = success, non-zero = error.
+                    BtdrvAddress addr;           ///< \ref BtdrvAddress
+                    u8 pad[2];                   ///< Padding
                 };
             };
-        } set_report;                        ///< ::BtdrvHidEventType_SetReport
+        } set_report;                            ///< ::BtdrvHidEventType_SetReport
 
         struct {
             union {
@@ -158,21 +181,21 @@ typedef struct {
                     struct {
                         BtdrvAddress addr;       ///< \ref BtdrvAddress
                         u8 pad[2];               ///< Padding
-                        u32 res;                 ///< 0 = success, non-zero = error. hid-sysmodule only uses the below data when this field is 0.
-                        BtdrvHidData data;       ///< \ref BtdrvHidData
+                        u32 res;                 ///< Unknown. hid-sysmodule only uses the below data when this field is 0.
+                        BtdrvHidData report;     ///< \ref BtdrvHidData
                         u8 pad2[2];              ///< Padding
                     };
-                } hid_data;                      ///< Pre-9.0.0
+                } v1;                            ///< Pre-9.0.0
 
                 union {
                     u8 rawdata[0x2C8];           ///< Raw data.
 
                     struct {
-                        u32 res;                 ///< 0 = success, non-zero = error. hid-sysmodule only uses the below report when this field is 0.
+                        u32 res;                 ///< Unknown. hid-sysmodule only uses the below report when this field is 0.
                         BtdrvAddress addr;       ///< \ref BtdrvAddress
                         BtdrvHidReport report;   ///< \ref BtdrvHidReport
                     };
-                } hid_report;                    ///< [9.0.0+]
+                } v9;                            ///< [9.0.0+]
             };
         } get_report;                            ///< ::BtdrvHidEventType_GetReport
     };
@@ -187,42 +210,7 @@ typedef struct {
         u64 size;
     } hdr;
 
-    union {
-        struct {
-            struct {
-                u8 unused[0x3];                  ///< Unused
-                BtdrvAddress addr;               ///< \ref BtdrvAddress
-                u8 unused2[0x3];                 ///< Unused
-                u16 size;                        ///< Size of the below data.
-                u8 data[];                       ///< Data.
-            } v1;                                ///< Pre-9.0.0
-
-            struct {
-                u8 unused[0x4];                  ///< Unused
-                u8 unused_x4;                    ///< Unused
-                BtdrvAddress addr;               ///< \ref BtdrvAddress
-                u8 pad;                          ///< Padding
-                u16 size;                        ///< Size of the below data.
-                u8 data[];                       ///< Data.
-            } v9;                                ///< [9.0.0+]
-        } data_report;                           ///< ::BtdrvHidEventType_Data
-
-        struct {
-            u8 data[0xC];                        ///< Raw data.
-        } set_report;                            ///< ::BtdrvHidEventType_SetReport
-
-        struct {
-            union {
-                struct {
-                    u8 rawdata[0x290];           ///< Raw data.
-                } hid_data;                      ///< Pre-9.0.0
-
-                struct {
-                    u8 rawdata[0x2C8];           ///< Raw data.
-                } hid_report;                    ///< [9.0.0+]
-            };
-        } get_report;                            ///< ::BtdrvHidEventType_GetReport
-    } data;
+    BtdrvHidReportEventInfo data;
 } BtdrvHidReportEventInfoBufferData;
 
 /// CircularBuffer
@@ -236,6 +224,99 @@ typedef struct {
     char name[0x11];
     u8 initialized;
 } BtdrvCircularBuffer;
+
+/// Data for \ref btdrvGetBleManagedEventInfo. The data stored here depends on the \ref BtdrvBleEventType.
+typedef struct {
+    union {
+        u8 data[0x400];
+
+        struct {
+            u32 status;
+            u8 handle;
+            bool registered;
+        } type0;
+
+        struct {
+            u32 status;
+            u32 conn_id;
+            u32 unk_x8;
+            u32 unk_xC;
+        } type2;
+
+        struct {
+            u32 conn_id;
+            u16 min_interval;
+            u16 max_interval;
+            u16 slave_latency;
+            u16 timeout_multiplier;
+        } type3; // Connection params
+
+        struct {
+            u32 status;
+            u8 unk_x4;
+            u8 unk_x5;
+            u8 unk_x6;
+            u8 unk_x7;
+            u32 conn_id;
+            BtdrvAddress address;
+            u16 unk_x12;
+        } type4; // Connection status
+
+        struct {
+            u32 status;
+            u8 unk_x4;
+            u8 unk_x5;
+            u8 unk_x6;
+            BtdrvAddress address;
+            BtdrvBleAdvertisementData adv[10];
+            u8 count;
+            u32 unk_x144;
+        } type6; // Scan result
+
+        struct {
+            u32 status;
+            u32 conn_id;
+        } type7;
+
+        struct {
+            u32 status;
+            u8 interface;
+            u8 unk_x5;
+            u16 unk_x6;
+            u32 unk_x8;
+            BtdrvGattAttributeUuid svc_uuid;
+            BtdrvGattAttributeUuid char_uuid;
+            BtdrvGattAttributeUuid descr_uuid;
+            u16 size;
+            u8 data[0x202];
+        } type8; // Notification
+
+        struct {
+            u32 status;
+            u32 conn_id;
+            u32 unk_x8;
+            u8 unk_xC[0x140];
+        } type9;
+
+        struct {
+            u32 status;
+            u32 conn_id;
+            u8 unk_x8[0x24];
+            u32 unk_x2C;
+            u8 unk_x30[0x11c];
+        } type10;
+
+        struct {
+            u32 status;
+            u32 conn_id;
+            u16 unk_x8;
+        } type11;
+
+        struct {
+            u8 unk_x0[0x218];
+        } type13;
+    };
+} BtdrvBleEventInfo;
 
 /// Initialize btdrv.
 Result btdrvInitialize(void);
@@ -354,9 +435,9 @@ Result btdrvRespondToSspRequest(BtdrvAddress addr, u8 variant, bool flag, u32 un
  * @note This is used by btm-sysmodule.
  * @param[out] buffer Output buffer, see \ref BtdrvEventInfo.
  * @param[in] size Output buffer size.
- * @oaram[out] type Output EventType.
+ * @oaram[out] type Output BtdrvEventType.
  */
-Result btdrvGetEventInfo(void* buffer, size_t size, u32 *type);
+Result btdrvGetEventInfo(void* buffer, size_t size, BtdrvEventType *type);
 
 /**
  * @brief InitializeHid
@@ -876,9 +957,9 @@ Result btdrvAddGattDescriptor(u8 unk0, const BtdrvGattAttributeUuid *uuid0, cons
  * @note This is used by btm-sysmodule.
  * @param[out] buffer Output buffer. 0x400-bytes from state is written here.
  * @param[in] size Output buffer size.
- * @oaram[out] type Output BleEventType.
+ * @oaram[out] type Output BtdrvBleEventType.
  */
-Result btdrvGetBleManagedEventInfo(void* buffer, size_t size, u32 *type);
+Result btdrvGetBleManagedEventInfo(void* buffer, size_t size, BtdrvBleEventType *type);
 
 /**
  * @brief GetGattFirstCharacteristic

--- a/nx/include/switch/services/btdrv_types.h
+++ b/nx/include/switch/services/btdrv_types.h
@@ -16,7 +16,7 @@ typedef enum {
     BtdrvBluetoothPropertyType_FeatureSet     =    6,    ///< 1-byte, FeatureSet. The default is value 0x68.
 } BtdrvBluetoothPropertyType;
 
-/// EventType
+/// EventType [1.0.0-11.0.1]
 typedef enum {
     BtdrvEventType_Unknown0                 =    0,    ///< Unused
     BtdrvEventType_InquiryDevice            =    3,    ///< Device found during Inquiry.
@@ -27,7 +27,22 @@ typedef enum {
     BtdrvEventType_BluetoothCrash           =    13,   ///< BluetoothCrash
 } BtdrvEventType;
 
-/// BtdrvInquiryStatus
+/// EventType [12.0.0]
+typedef enum {
+    BtdrvEventTypeV12_InquiryDevice             =     0,   ///< Device found during Inquiry.
+    BtdrvEventTypeV12_InquiryStatus             =     1,   ///< Inquiry status changed.
+    BtdrvEventTypeV12_PairingPinCodeRequest     =     2,   ///< Pairing PIN code request.
+    BtdrvEventTypeV12_SspRequest                =     3,   ///< SSP confirm request / SSP passkey notification.
+    BtdrvEventTypeV12_Connection                =     4,   ///< Connection
+    BtdrvEventTypeV12_Tsi                       =     5,   ///< SetTsi (\ref btdrvSetTsi)
+    BtdrvEventTypeV12_BurstMode                 =     6,   ///< SetBurstMode (\ref btdrvEnableBurstMode)
+    BtdrvEventTypeV12_SetZeroRetransmission     =     7,   ///< \ref btdrvSetZeroRetransmission
+    BtdrvEventTypeV12_PendingConnections        =     8,   ///< \ref btdrvGetPendingConnections
+    BtdrvEventTypeV12_MoveToSecondaryPiconet    =     9,   ///< \ref btdrvMoveToSecondaryPiconet
+    BtdrvEventTypeV12_BluetoothCrash            =    10,   ///< BluetoothCrash
+} BtdrvEventTypeV12;
+
+/// BtdrvInquiryStatus 
 typedef enum {
     BtdrvInquiryStatus_Stopped    =    0,   ///< Inquiry started.
     BtdrvInquiryStatus_Started    =    1,   ///< Inquiry stopped.
@@ -40,7 +55,7 @@ typedef enum {
     BtdrvConnectionEventType_Suspended           =     2,   ///< ACL Link is now Suspended.
 } BtdrvConnectionEventType;
 
-/// ExtEventType
+/// ExtEventType [1.0.0-11.0.1]
 typedef enum {
     BtdrvExtEventType_SetTsi                     =     0,   ///< SetTsi (\ref btdrvSetTsi)
     BtdrvExtEventType_ExitTsi                    =     1,   ///< ExitTsi (\ref btdrvSetTsi)
@@ -61,7 +76,7 @@ typedef enum {
     BtdrvBluetoothHhReportType_Feature      =    3,    ///< Feature
 } BtdrvBluetoothHhReportType;
 
-/// HidEventType
+/// HidEventType [1.0.0-11.0.1]
 typedef enum {
     BtdrvHidEventType_Connection            =    0,    ///< Connection. Only used with \ref btdrvGetHidEventInfo.
     BtdrvHidEventType_Data                  =    4,    ///< DATA report on the Interrupt channel.
@@ -70,12 +85,26 @@ typedef enum {
     BtdrvHidEventType_GetReport             =    9,    ///< Response to GET_REPORT.
 } BtdrvHidEventType;
 
+/// HidEventType [12.0.0]
+typedef enum {
+    BtdrvHidEventTypeV12_Connection         =    0,    ///< Connection. Only used with \ref btdrvGetHidEventInfo.
+    BtdrvHidEventTypeV12_Data               =    1,    ///< DATA report on the Interrupt channel.
+    BtdrvHidEventTypeV12_SetReport          =    2,    ///< Response to SET_REPORT.
+    BtdrvHidEventTypeV12_GetReport          =    3,    ///< Response to GET_REPORT.
+} BtdrvHidEventTypeV12;
+
 /// HidConnectionStatus
 typedef enum {
     BtdrvHidConnectionStatus_Connected      =    0,
     BtdrvHidConnectionStatus_Disconnected   =    2,
     BtdrvHidConnectionStatus_FailedGeneric  =    8,
 } BtdrvHidConnectionStatus;
+
+/// HidConnectionStatusV12
+typedef enum {
+    BtdrvHidConnectionStatusV12_Disconnected   =    0,
+    BtdrvHidConnectionStatusV12_Connected      =    1,
+} BtdrvHidConnectionStatusV12;
 
 /// This determines the u16 data to write into a CircularBuffer.
 typedef enum {
@@ -126,6 +155,12 @@ typedef struct {
 typedef struct {
     char code[0x10];           ///< PinCode
 } BtdrvBluetoothPinCode;
+
+/// BtdrvPinCode
+typedef struct {
+    char code[0x10];           ///< PinCode
+    u8 length;                 ///< Length 
+} BtdrvPinCode;
 
 /// HidData, for pre-9.0.0.
 typedef struct {

--- a/nx/include/switch/services/btdrv_types.h
+++ b/nx/include/switch/services/btdrv_types.h
@@ -7,7 +7,7 @@
 #pragma once
 #include "../types.h"
 
-/// BluetoothPropertyType
+/// BluetoothPropertyType [1.0.0-11.0.1]
 typedef enum {
     BtdrvBluetoothPropertyType_Name              =     1,    ///< Name. String, max length 0xF8 excluding NUL-terminator.
     BtdrvBluetoothPropertyType_Address           =     2,    ///< \ref BtdrvAddress
@@ -15,6 +15,14 @@ typedef enum {
     BtdrvBluetoothPropertyType_ClassOfDevice     =     5,    ///< 3-bytes, Class of Device.
     BtdrvBluetoothPropertyType_FeatureSet        =     6,    ///< 1-byte, FeatureSet. The default is value 0x68.
 } BtdrvBluetoothPropertyType;
+
+/// AdapterPropertyType [12.0.0+]
+typedef enum {
+    BtdrvAdapterPropertyType_Address             =     0,    ///< \ref BtdrvAddress
+    BtdrvAdapterPropertyType_Name                =     1,    ///< Name. String, max length 0xF8 excluding NUL-terminator.
+    BtdrvAdapterPropertyType_ClassOfDevice       =     2,    ///< 3-bytes, Class of Device.
+    BtdrvAdapterPropertyType_Unknown3            =     3,    ///< Only available with \ref btdrvSetAdapterProperty. Unknown, \ref BtdrvAddress.
+} BtdrvAdapterPropertyType;
 
 /// EventType
 typedef enum {
@@ -140,13 +148,27 @@ typedef struct {
     u8 class_of_device[0x3];   ///< ClassOfDevice
 } BtdrvClassOfDevice;
 
-/// AdapterProperty
+/// AdapterProperty [1.0.0-11.0.1]
 typedef struct {
     BtdrvAddress addr;                      ///< Same as the data for ::BtdrvBluetoothPropertyType_Address.
     BtdrvClassOfDevice class_of_device;     ///< Same as the data for ::BtdrvBluetoothPropertyType_ClassOfDevice.
     char name[0xF9];                        ///< Same as the data for ::BtdrvBluetoothPropertyType_Name (last byte is not initialized).
     u8 feature_set;                         ///< Set to hard-coded value 0x68 (same as the data for ::BtdrvBluetoothPropertyType_FeatureSet).
+} BtdrvAdapterPropertyOld;
+
+/// AdapterProperty [12.0.0+]
+typedef struct {
+    u8 type;                                ///< \ref BtdrvAdapterPropertyType
+    u8 size;                                ///< Data size.
+    u8 data[0x100];                         ///< Data (Above size), as specified by the type.
 } BtdrvAdapterProperty;
+
+/// AdapterPropertySet [12.0.0+]
+typedef struct {
+    BtdrvAddress addr;                      ///< Same as the data for ::BtdrvBluetoothPropertyType_Address.
+    BtdrvClassOfDevice class_of_device;     ///< Same as the data for ::BtdrvBluetoothPropertyType_ClassOfDevice.
+    char name[0xF9];                        ///< Same as the data for ::BtdrvBluetoothPropertyType_Name (last byte is not initialized).
+} BtdrvAdapterPropertySet;
 
 /// BluetoothPinCode [1.0.0-11.0.1]
 typedef struct {

--- a/nx/include/switch/services/btdrv_types.h
+++ b/nx/include/switch/services/btdrv_types.h
@@ -9,42 +9,42 @@
 
 /// BluetoothPropertyType
 typedef enum {
-    BtdrvBluetoothPropertyType_Name           =    1,    ///< Name. String, max length 0xF8 excluding NUL-terminator.
-    BtdrvBluetoothPropertyType_Address        =    2,    ///< \ref BtdrvAddress
-    BtdrvBluetoothPropertyType_Unknown3       =    3,    ///< Only available with \ref btdrvSetAdapterProperty. Unknown, \ref BtdrvAddress.
-    BtdrvBluetoothPropertyType_ClassOfDevice  =    5,    ///< 3-bytes, Class of Device.
-    BtdrvBluetoothPropertyType_FeatureSet     =    6,    ///< 1-byte, FeatureSet. The default is value 0x68.
+    BtdrvBluetoothPropertyType_Name              =     1,    ///< Name. String, max length 0xF8 excluding NUL-terminator.
+    BtdrvBluetoothPropertyType_Address           =     2,    ///< \ref BtdrvAddress
+    BtdrvBluetoothPropertyType_Unknown3          =     3,    ///< Only available with \ref btdrvSetAdapterProperty. Unknown, \ref BtdrvAddress.
+    BtdrvBluetoothPropertyType_ClassOfDevice     =     5,    ///< 3-bytes, Class of Device.
+    BtdrvBluetoothPropertyType_FeatureSet        =     6,    ///< 1-byte, FeatureSet. The default is value 0x68.
 } BtdrvBluetoothPropertyType;
 
 /// EventType
 typedef enum {
     ///< BtdrvEventType_* should be used on [12.0.0+]
-    BtdrvEventType_InquiryDevice             =     0,   ///< Device found during Inquiry.
-    BtdrvEventType_InquiryStatus             =     1,   ///< Inquiry status changed.
-    BtdrvEventType_PairingPinCodeRequest     =     2,   ///< Pairing PIN code request.
-    BtdrvEventType_SspRequest                =     3,   ///< SSP confirm request / SSP passkey notification.
-    BtdrvEventType_Connection                =     4,   ///< Connection
-    BtdrvEventType_Tsi                       =     5,   ///< SetTsi (\ref btdrvSetTsi)
-    BtdrvEventType_BurstMode                 =     6,   ///< SetBurstMode (\ref btdrvEnableBurstMode)
-    BtdrvEventType_SetZeroRetransmission     =     7,   ///< \ref btdrvSetZeroRetransmission
-    BtdrvEventType_PendingConnections        =     8,   ///< \ref btdrvGetPendingConnections
-    BtdrvEventType_MoveToSecondaryPiconet    =     9,   ///< \ref btdrvMoveToSecondaryPiconet
-    BtdrvEventType_BluetoothCrash            =    10,   ///< BluetoothCrash
+    BtdrvEventType_InquiryDevice                 =     0,    ///< Device found during Inquiry.
+    BtdrvEventType_InquiryStatus                 =     1,    ///< Inquiry status changed.
+    BtdrvEventType_PairingPinCodeRequest         =     2,    ///< Pairing PIN code request.
+    BtdrvEventType_SspRequest                    =     3,    ///< SSP confirm request / SSP passkey notification.
+    BtdrvEventType_Connection                    =     4,    ///< Connection
+    BtdrvEventType_Tsi                           =     5,    ///< SetTsi (\ref btdrvSetTsi)
+    BtdrvEventType_BurstMode                     =     6,    ///< SetBurstMode (\ref btdrvEnableBurstMode)
+    BtdrvEventType_SetZeroRetransmission         =     7,    ///< \ref btdrvSetZeroRetransmission
+    BtdrvEventType_PendingConnections            =     8,    ///< \ref btdrvGetPendingConnections
+    BtdrvEventType_MoveToSecondaryPiconet        =     9,    ///< \ref btdrvMoveToSecondaryPiconet
+    BtdrvEventType_BluetoothCrash                =    10,    ///< BluetoothCrash
 
     ///< BtdrvEventTypeOld_* should be used on [1.0.0-11.0.1]
-    BtdrvEventTypeOld_Unknown0                 =    0,    ///< Unused
-    BtdrvEventTypeOld_InquiryDevice            =    3,    ///< Device found during Inquiry.
-    BtdrvEventTypeOld_InquiryStatus            =    4,    ///< Inquiry status changed.
-    BtdrvEventTypeOld_PairingPinCodeRequest    =    5,    ///< Pairing PIN code request.
-    BtdrvEventTypeOld_SspRequest               =    6,    ///< SSP confirm request / SSP passkey notification.
-    BtdrvEventTypeOld_Connection               =    7,    ///< Connection
-    BtdrvEventTypeOld_BluetoothCrash           =    13,   ///< BluetoothCrash
+    BtdrvEventTypeOld_Unknown0                   =     0,    ///< Unused
+    BtdrvEventTypeOld_InquiryDevice              =     3,    ///< Device found during Inquiry.
+    BtdrvEventTypeOld_InquiryStatus              =     4,    ///< Inquiry status changed.
+    BtdrvEventTypeOld_PairingPinCodeRequest      =     5,    ///< Pairing PIN code request.
+    BtdrvEventTypeOld_SspRequest                 =     6,    ///< SSP confirm request / SSP passkey notification.
+    BtdrvEventTypeOld_Connection                 =     7,    ///< Connection
+    BtdrvEventTypeOld_BluetoothCrash             =    13,    ///< BluetoothCrash
 } BtdrvEventType;
 
 /// BtdrvInquiryStatus 
 typedef enum {
-    BtdrvInquiryStatus_Stopped    =    0,   ///< Inquiry started.
-    BtdrvInquiryStatus_Started    =    1,   ///< Inquiry stopped.
+    BtdrvInquiryStatus_Stopped                   =     0,    ///< Inquiry started.
+    BtdrvInquiryStatus_Started                   =     1,    ///< Inquiry stopped.
 } BtdrvInquiryStatus;
 
 /// ConnectionEventType
@@ -69,10 +69,10 @@ typedef enum {
 /// Bit0-1 directly control the HID bluetooth transaction report-type value.
 /// Bit2-3: these directly control the Parameter Reserved field for SetReport, for GetReport these control the Parameter Reserved and Size bits.
 typedef enum {
-    BtdrvBluetoothHhReportType_Other        =    0,    ///< Other
-    BtdrvBluetoothHhReportType_Input        =    1,    ///< Input
-    BtdrvBluetoothHhReportType_Output       =    2,    ///< Output
-    BtdrvBluetoothHhReportType_Feature      =    3,    ///< Feature
+    BtdrvBluetoothHhReportType_Other             =    0,    ///< Other
+    BtdrvBluetoothHhReportType_Input             =    1,    ///< Input
+    BtdrvBluetoothHhReportType_Output            =    2,    ///< Output
+    BtdrvBluetoothHhReportType_Feature           =    3,    ///< Feature
 } BtdrvBluetoothHhReportType;
 
 /// HidEventType

--- a/nx/include/switch/services/btdrv_types.h
+++ b/nx/include/switch/services/btdrv_types.h
@@ -27,6 +27,12 @@ typedef enum {
     BtdrvEventType_BluetoothCrash           =    13,   ///< BluetoothCrash
 } BtdrvEventType;
 
+/// BtdrvInquiryStatus
+typedef enum {
+    BtdrvInquiryStatus_Stopped    =    0,   ///< Inquiry started.
+    BtdrvInquiryStatus_Started    =    1,   ///< Inquiry stopped.
+} BtdrvInquiryStatus;
+
 /// ConnectionEventType
 typedef enum {
     BtdrvConnectionEventType_Status              =     0,   ///< BtdrvEventInfo::connection::status
@@ -64,6 +70,13 @@ typedef enum {
     BtdrvHidEventType_GetReport             =    9,    ///< Response to GET_REPORT.
 } BtdrvHidEventType;
 
+/// HidConnectionStatus
+typedef enum {
+    BtdrvHidConnectionStatus_Connected      =    0,
+    BtdrvHidConnectionStatus_Disconnected   =    2,
+    BtdrvHidConnectionStatus_FailedGeneric  =    8,
+} BtdrvHidConnectionStatus;
+
 /// This determines the u16 data to write into a CircularBuffer.
 typedef enum {
     BtdrvFatalReason_Invalid                =    0,    ///< Only for \ref BtdrvEventInfo: invalid.
@@ -73,17 +86,40 @@ typedef enum {
     BtdrvFatalReason_Enable                 =    7,    ///< Only for \ref BtdrvEventInfo: triggered after enabling bluetooth, depending on the value of a global state field.
 } BtdrvFatalReason;
 
+/// BleEventType
+typedef enum {
+    BtdrvBleEventType_Unknown0              =    0,    ///< Unknown.
+    BtdrvBleEventType_Unknown1              =    1,    ///< Unknown.
+    BtdrvBleEventType_Unknown2              =    2,    ///< Unknown.
+    BtdrvBleEventType_Unknown3              =    3,    ///< Unknown.
+    BtdrvBleEventType_Unknown4              =    4,    ///< Unknown.
+    BtdrvBleEventType_Unknown5              =    5,    ///< Unknown.
+    BtdrvBleEventType_Unknown6              =    6,    ///< Unknown.
+    BtdrvBleEventType_Unknown7              =    7,    ///< Unknown.
+    BtdrvBleEventType_Unknown8              =    8,    ///< Unknown.
+    BtdrvBleEventType_Unknown9              =    9,    ///< Unknown.
+    BtdrvBleEventType_Unknown10             =   10,    ///< Unknown.
+    BtdrvBleEventType_Unknown11             =   11,    ///< Unknown.
+    BtdrvBleEventType_Unknown12             =   12,    ///< Unknown.
+    BtdrvBleEventType_Unknown13             =   13,    ///< Unknown.
+} BtdrvBleEventType;
+
 /// Address
 typedef struct {
     u8 address[0x6];           ///< Address
 } BtdrvAddress;
 
+/// ClassOfDevice
+typedef struct {
+    u8 class_of_device[0x3];   ///< ClassOfDevice
+} BtdrvClassOfDevice;
+
 /// AdapterProperty
 typedef struct {
-    BtdrvAddress addr;         ///< Same as the data for ::BtdrvBluetoothPropertyType_Address.
-    u8 class_of_device[0x3];   ///< Same as the data for ::BtdrvBluetoothPropertyType_ClassOfDevice.
-    char name[0xF9];           ///< Same as the data for ::BtdrvBluetoothPropertyType_Name (last byte is not initialized).
-    u8 feature_set;            ///< Set to hard-coded value 0x68 (same as the data for ::BtdrvBluetoothPropertyType_FeatureSet).
+    BtdrvAddress addr;                      ///< Same as the data for ::BtdrvBluetoothPropertyType_Address.
+    BtdrvClassOfDevice class_of_device;     ///< Same as the data for ::BtdrvBluetoothPropertyType_ClassOfDevice.
+    char name[0xF9];                        ///< Same as the data for ::BtdrvBluetoothPropertyType_Name (last byte is not initialized).
+    u8 feature_set;                         ///< Set to hard-coded value 0x68 (same as the data for ::BtdrvBluetoothPropertyType_FeatureSet).
 } BtdrvAdapterProperty;
 
 /// BluetoothPinCode
@@ -153,6 +189,12 @@ typedef struct {
     u8 unk_xC8;                                      ///< Unknown
     u8 pad5[3];                                      ///< Padding
 } BtdrvBleAdvertisePacketData;
+
+typedef struct {
+    u8 length;
+    u8 type;
+    u8 value[0x1d];
+} BtdrvBleAdvertisementData;
 
 /// BleAdvertiseFilter
 typedef struct {

--- a/nx/include/switch/services/btdrv_types.h
+++ b/nx/include/switch/services/btdrv_types.h
@@ -91,7 +91,7 @@ typedef enum {
     BtdrvHidEventTypeOld_GetReport       =    9,    ///< Response to GET_REPORT.
 } BtdrvHidEventType;
 
-/// HidConnectionStatus [12.0.0]
+/// HidConnectionStatus [12.0.0+]
 typedef enum {
     ///< BtdrvHidConnectionStatus_* should be used on [12.0.0+]
     BtdrvHidConnectionStatus_Disconnected       =    0,
@@ -148,7 +148,7 @@ typedef struct {
     u8 feature_set;                         ///< Set to hard-coded value 0x68 (same as the data for ::BtdrvBluetoothPropertyType_FeatureSet).
 } BtdrvAdapterProperty;
 
-/// BluetoothPinCode
+/// BluetoothPinCode [1.0.0-11.0.1]
 typedef struct {
     char code[0x10];           ///< PinCode
 } BtdrvBluetoothPinCode;
@@ -159,13 +159,13 @@ typedef struct {
     u8 length;                 ///< Length 
 } BtdrvPinCode;
 
-/// HidData, for pre-9.0.0.
+/// HidData [1.0.0-8.1.1]
 typedef struct {
     u16 size;                  ///< Size of data.
     u8 data[0x280];            ///< Data
 } BtdrvHidData;
 
-/// HidReport, for [9.0.0+].
+/// HidReport [9.0.0+].
 typedef struct {
     u16 size;                  ///< Size of data.
     u8 data[0x2BC];            ///< Data

--- a/nx/include/switch/services/btdrv_types.h
+++ b/nx/include/switch/services/btdrv_types.h
@@ -94,13 +94,13 @@ typedef enum {
 /// HidConnectionStatus [12.0.0+]
 typedef enum {
     ///< BtdrvHidConnectionStatus_* should be used on [12.0.0+]
-    BtdrvHidConnectionStatus_Disconnected       =    0,
-    BtdrvHidConnectionStatus_Connected          =    1,
+    BtdrvHidConnectionStatus_Closed      =    0,
+    BtdrvHidConnectionStatus_Opened      =    1,
 
     ///< BtdrvHidConnectionStatusOld_* should be used on [1.0.0-11.0.1]
-    BtdrvHidConnectionStatusOld_Connected       =    0,
-    BtdrvHidConnectionStatusOld_Disconnected    =    2,
-    BtdrvHidConnectionStatusOld_FailedGeneric   =    8,
+    BtdrvHidConnectionStatusOld_Opened   =    0,
+    BtdrvHidConnectionStatusOld_Closed   =    2,
+    BtdrvHidConnectionStatusOld_Failed   =    8,
 } BtdrvHidConnectionStatus;
 
 /// This determines the u16 data to write into a CircularBuffer.

--- a/nx/include/switch/services/btdrv_types.h
+++ b/nx/include/switch/services/btdrv_types.h
@@ -1,7 +1,7 @@
 /**
  * @file btdrv_types.h
  * @brief Bluetooth driver (btdrv) service types (see btdrv.h for the rest).
- * @author yellows8
+ * @author yellows8, ndeadly
  * @copyright libnx Authors
  */
 #pragma once
@@ -16,31 +16,30 @@ typedef enum {
     BtdrvBluetoothPropertyType_FeatureSet     =    6,    ///< 1-byte, FeatureSet. The default is value 0x68.
 } BtdrvBluetoothPropertyType;
 
-/// EventType [1.0.0-11.0.1]
+/// EventType
 typedef enum {
-    BtdrvEventType_Unknown0                 =    0,    ///< Unused
-    BtdrvEventType_InquiryDevice            =    3,    ///< Device found during Inquiry.
-    BtdrvEventType_InquiryStatus            =    4,    ///< Inquiry status changed.
-    BtdrvEventType_PairingPinCodeRequest    =    5,    ///< Pairing PIN code request.
-    BtdrvEventType_SspRequest               =    6,    ///< SSP confirm request / SSP passkey notification.
-    BtdrvEventType_Connection               =    7,    ///< Connection
-    BtdrvEventType_BluetoothCrash           =    13,   ///< BluetoothCrash
-} BtdrvEventType;
+    ///< BtdrvEventType_* should be used on [12.0.0+]
+    BtdrvEventType_InquiryDevice             =     0,   ///< Device found during Inquiry.
+    BtdrvEventType_InquiryStatus             =     1,   ///< Inquiry status changed.
+    BtdrvEventType_PairingPinCodeRequest     =     2,   ///< Pairing PIN code request.
+    BtdrvEventType_SspRequest                =     3,   ///< SSP confirm request / SSP passkey notification.
+    BtdrvEventType_Connection                =     4,   ///< Connection
+    BtdrvEventType_Tsi                       =     5,   ///< SetTsi (\ref btdrvSetTsi)
+    BtdrvEventType_BurstMode                 =     6,   ///< SetBurstMode (\ref btdrvEnableBurstMode)
+    BtdrvEventType_SetZeroRetransmission     =     7,   ///< \ref btdrvSetZeroRetransmission
+    BtdrvEventType_PendingConnections        =     8,   ///< \ref btdrvGetPendingConnections
+    BtdrvEventType_MoveToSecondaryPiconet    =     9,   ///< \ref btdrvMoveToSecondaryPiconet
+    BtdrvEventType_BluetoothCrash            =    10,   ///< BluetoothCrash
 
-/// EventType [12.0.0]
-typedef enum {
-    BtdrvEventTypeV12_InquiryDevice             =     0,   ///< Device found during Inquiry.
-    BtdrvEventTypeV12_InquiryStatus             =     1,   ///< Inquiry status changed.
-    BtdrvEventTypeV12_PairingPinCodeRequest     =     2,   ///< Pairing PIN code request.
-    BtdrvEventTypeV12_SspRequest                =     3,   ///< SSP confirm request / SSP passkey notification.
-    BtdrvEventTypeV12_Connection                =     4,   ///< Connection
-    BtdrvEventTypeV12_Tsi                       =     5,   ///< SetTsi (\ref btdrvSetTsi)
-    BtdrvEventTypeV12_BurstMode                 =     6,   ///< SetBurstMode (\ref btdrvEnableBurstMode)
-    BtdrvEventTypeV12_SetZeroRetransmission     =     7,   ///< \ref btdrvSetZeroRetransmission
-    BtdrvEventTypeV12_PendingConnections        =     8,   ///< \ref btdrvGetPendingConnections
-    BtdrvEventTypeV12_MoveToSecondaryPiconet    =     9,   ///< \ref btdrvMoveToSecondaryPiconet
-    BtdrvEventTypeV12_BluetoothCrash            =    10,   ///< BluetoothCrash
-} BtdrvEventTypeV12;
+    ///< BtdrvEventTypeOld_* should be used on [1.0.0-11.0.1]
+    BtdrvEventTypeOld_Unknown0                 =    0,    ///< Unused
+    BtdrvEventTypeOld_InquiryDevice            =    3,    ///< Device found during Inquiry.
+    BtdrvEventTypeOld_InquiryStatus            =    4,    ///< Inquiry status changed.
+    BtdrvEventTypeOld_PairingPinCodeRequest    =    5,    ///< Pairing PIN code request.
+    BtdrvEventTypeOld_SspRequest               =    6,    ///< SSP confirm request / SSP passkey notification.
+    BtdrvEventTypeOld_Connection               =    7,    ///< Connection
+    BtdrvEventTypeOld_BluetoothCrash           =    13,   ///< BluetoothCrash
+} BtdrvEventType;
 
 /// BtdrvInquiryStatus 
 typedef enum {
@@ -76,35 +75,33 @@ typedef enum {
     BtdrvBluetoothHhReportType_Feature      =    3,    ///< Feature
 } BtdrvBluetoothHhReportType;
 
-/// HidEventType [1.0.0-11.0.1]
+/// HidEventType
 typedef enum {
-    BtdrvHidEventType_Connection            =    0,    ///< Connection. Only used with \ref btdrvGetHidEventInfo.
-    BtdrvHidEventType_Data                  =    4,    ///< DATA report on the Interrupt channel.
-    BtdrvHidEventType_Ext                   =    7,    ///< Response for extensions. Only used with \ref btdrvGetHidEventInfo.
-    BtdrvHidEventType_SetReport             =    8,    ///< Response to SET_REPORT.
-    BtdrvHidEventType_GetReport             =    9,    ///< Response to GET_REPORT.
+    ///< BtdrvHidEventType_* should be used on [12.0.0+]
+    BtdrvHidEventType_Connection         =    0,    ///< Connection. Only used with \ref btdrvGetHidEventInfo.
+    BtdrvHidEventType_Data               =    1,    ///< DATA report on the Interrupt channel.
+    BtdrvHidEventType_SetReport          =    2,    ///< Response to SET_REPORT.
+    BtdrvHidEventType_GetReport          =    3,    ///< Response to GET_REPORT.
+
+    ///< BtdrvHidEventTypeOld_* should be used on [1.0.0-11.0.1]
+    BtdrvHidEventTypeOld_Connection      =    0,    ///< Connection. Only used with \ref btdrvGetHidEventInfo.
+    BtdrvHidEventTypeOld_Data            =    4,    ///< DATA report on the Interrupt channel.
+    BtdrvHidEventTypeOld_Ext             =    7,    ///< Response for extensions. Only used with \ref btdrvGetHidEventInfo.
+    BtdrvHidEventTypeOld_SetReport       =    8,    ///< Response to SET_REPORT.
+    BtdrvHidEventTypeOld_GetReport       =    9,    ///< Response to GET_REPORT.
 } BtdrvHidEventType;
 
-/// HidEventType [12.0.0]
+/// HidConnectionStatus [12.0.0]
 typedef enum {
-    BtdrvHidEventTypeV12_Connection         =    0,    ///< Connection. Only used with \ref btdrvGetHidEventInfo.
-    BtdrvHidEventTypeV12_Data               =    1,    ///< DATA report on the Interrupt channel.
-    BtdrvHidEventTypeV12_SetReport          =    2,    ///< Response to SET_REPORT.
-    BtdrvHidEventTypeV12_GetReport          =    3,    ///< Response to GET_REPORT.
-} BtdrvHidEventTypeV12;
+    ///< BtdrvHidConnectionStatus_* should be used on [12.0.0+]
+    BtdrvHidConnectionStatus_Disconnected       =    0,
+    BtdrvHidConnectionStatus_Connected          =    1,
 
-/// HidConnectionStatus
-typedef enum {
-    BtdrvHidConnectionStatus_Connected      =    0,
-    BtdrvHidConnectionStatus_Disconnected   =    2,
-    BtdrvHidConnectionStatus_FailedGeneric  =    8,
+    ///< BtdrvHidConnectionStatusOld_* should be used on [1.0.0-11.0.1]
+    BtdrvHidConnectionStatusOld_Connected       =    0,
+    BtdrvHidConnectionStatusOld_Disconnected    =    2,
+    BtdrvHidConnectionStatusOld_FailedGeneric   =    8,
 } BtdrvHidConnectionStatus;
-
-/// HidConnectionStatusV12
-typedef enum {
-    BtdrvHidConnectionStatusV12_Disconnected   =    0,
-    BtdrvHidConnectionStatusV12_Connected      =    1,
-} BtdrvHidConnectionStatusV12;
 
 /// This determines the u16 data to write into a CircularBuffer.
 typedef enum {
@@ -156,7 +153,7 @@ typedef struct {
     char code[0x10];           ///< PinCode
 } BtdrvBluetoothPinCode;
 
-/// BtdrvPinCode
+/// BtdrvPinCode [12.0.0+]
 typedef struct {
     char code[0x10];           ///< PinCode
     u8 length;                 ///< Length 

--- a/nx/source/services/btdrv.c
+++ b/nx/source/services/btdrv.c
@@ -157,14 +157,21 @@ Result btdrvFinalizeBluetooth(void) {
     return _btdrvCmdNoIO(4);
 }
 
-Result btdrvGetAdapterProperties(BtdrvAdapterProperty *property) {
+Result btdrvLegacyGetAdapterProperties(BtdrvAdapterPropertyOld *properties) {
     return serviceDispatch(&g_btdrvSrv, 5,
         .buffer_attrs = { SfBufferAttr_HipcPointer | SfBufferAttr_Out | SfBufferAttr_FixedSize },
-        .buffers = { { property, sizeof(*property) } },
+        .buffers = { { properties, sizeof(*properties) } },
     );
 }
 
-Result btdrvGetAdapterProperty(BtdrvBluetoothPropertyType type, void* buffer, size_t size) {
+Result btdrvGetAdapterProperties(BtdrvAdapterPropertySet *properties) {
+    return serviceDispatch(&g_btdrvSrv, 5,
+        .buffer_attrs = { SfBufferAttr_HipcPointer | SfBufferAttr_Out | SfBufferAttr_FixedSize },
+        .buffers = { { properties, sizeof(*properties) } },
+    );
+}
+
+Result btdrvLegacyGetAdapterProperty(BtdrvBluetoothPropertyType type, void* buffer, size_t size) {
     u32 tmp=type;
     return serviceDispatchIn(&g_btdrvSrv, 6, tmp,
         .buffer_attrs = { SfBufferAttr_HipcPointer | SfBufferAttr_Out },
@@ -172,11 +179,27 @@ Result btdrvGetAdapterProperty(BtdrvBluetoothPropertyType type, void* buffer, si
     );
 }
 
-Result btdrvSetAdapterProperty(BtdrvBluetoothPropertyType type, const void* buffer, size_t size) {
+Result btdrvGetAdapterProperty(BtdrvAdapterPropertyType type, BtdrvAdapterProperty *property) {
+    u32 tmp=type;
+    return serviceDispatchIn(&g_btdrvSrv, 6, tmp,
+        .buffer_attrs = { SfBufferAttr_HipcPointer | SfBufferAttr_Out | SfBufferAttr_FixedSize },
+        .buffers = { { property, sizeof(*property) } },
+    );
+}
+
+Result btdrvLegacySetAdapterProperty(BtdrvBluetoothPropertyType type, const void* buffer, size_t size) {
     u32 tmp=type;
     return serviceDispatchIn(&g_btdrvSrv, 7, tmp,
         .buffer_attrs = { SfBufferAttr_HipcPointer | SfBufferAttr_In },
         .buffers = { { buffer, size } },
+    );
+}
+
+Result btdrvSetAdapterProperty(BtdrvAdapterPropertyType type, const BtdrvAdapterProperty *property) {
+    u32 tmp=type;
+    return serviceDispatchIn(&g_btdrvSrv, 7, tmp,
+        .buffer_attrs = { SfBufferAttr_HipcPointer | SfBufferAttr_In | SfBufferAttr_FixedSize },
+        .buffers = { { property, sizeof(*property) } },
     );
 }
 

--- a/nx/source/services/btdrv.c
+++ b/nx/source/services/btdrv.c
@@ -213,15 +213,26 @@ Result btdrvCancelBond(BtdrvAddress addr) {
     return _btdrvCmdInAddrNoOut(addr, 12);
 }
 
-Result btdrvRespondToPinRequest(BtdrvAddress addr, bool flag, const BtdrvBluetoothPinCode *pin_code, u8 unk) {
-    const struct {
-        BtdrvAddress addr;
-        u8 flag;
-        u8 unk;
-        BtdrvBluetoothPinCode pin_code;
-    } in = { addr, flag!=0, unk, *pin_code };
+Result btdrvRespondToPinRequest(BtdrvAddress addr, bool flag, const BtdrvBluetoothPinCode *pin_code, u8 length) {
+    if (hosversionBefore(12,0,0)) {
+        const struct {
+            BtdrvAddress addr;
+            u8 flag;
+            u8 length;
+            BtdrvBluetoothPinCode pin_code;
+        } in = { addr, flag!=0, length, *pin_code };
 
-    return serviceDispatchIn(&g_btdrvSrv, 13, in);
+        return serviceDispatchIn(&g_btdrvSrv, 13, in);
+    }
+    else {
+        const struct {
+            BtdrvAddress addr;
+            BtdrvBluetoothPinCode pin_code;
+            uint8_t length;
+        } in = { addr, *pin_code, length };
+
+        return serviceDispatchIn(&g_btdrvSrv, 13, in);
+    }
 }
 
 Result btdrvRespondToSspRequest(BtdrvAddress addr, u8 variant, bool flag, u32 unk) {

--- a/nx/source/services/btdrv.c
+++ b/nx/source/services/btdrv.c
@@ -213,26 +213,30 @@ Result btdrvCancelBond(BtdrvAddress addr) {
     return _btdrvCmdInAddrNoOut(addr, 12);
 }
 
-Result btdrvRespondToPinRequest(BtdrvAddress addr, bool flag, const BtdrvBluetoothPinCode *pin_code, u8 length) {
-    if (hosversionBefore(12,0,0)) {
-        const struct {
-            BtdrvAddress addr;
-            u8 flag;
-            u8 length;
-            BtdrvBluetoothPinCode pin_code;
-        } in = { addr, flag!=0, length, *pin_code };
+Result btdrvLegacyRespondToPinRequest(BtdrvAddress addr, bool flag, const BtdrvBluetoothPinCode *pin_code, u8 length) {
+    if (hosversionAtLeast(12,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
 
-        return serviceDispatchIn(&g_btdrvSrv, 13, in);
-    }
-    else {
-        const struct {
-            BtdrvAddress addr;
-            BtdrvBluetoothPinCode pin_code;
-            uint8_t length;
-        } in = { addr, *pin_code, length };
+    const struct {
+        BtdrvAddress addr;
+        u8 flag;
+        u8 length;
+        BtdrvBluetoothPinCode pin_code;
+    } in = { addr, flag!=0, length, *pin_code };
 
-        return serviceDispatchIn(&g_btdrvSrv, 13, in);
-    }
+    return serviceDispatchIn(&g_btdrvSrv, 13, in);
+}
+
+Result btdrvRespondToPinRequest(BtdrvAddress addr, const BtdrvPinCode *pin_code) {
+    if (hosversionBefore(12,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    const struct {
+        BtdrvAddress addr;
+        BtdrvPinCode pin_code;
+    } in = { addr, *pin_code };
+
+    return serviceDispatchIn(&g_btdrvSrv, 13, in);
 }
 
 Result btdrvRespondToSspRequest(BtdrvAddress addr, u8 variant, bool flag, u32 unk) {


### PR DESCRIPTION
This PR is the first step toward upstreaming my work on btdrv. I've refined the various existing event info structures a bit, updated them for 12.0.0 and added some missing definitions for firmwares < 7.0.0. Crude definitions for BLE events have been added too, along with a bunch of other miscellaneous minor edits/additions

It's still a little rough around the edges, so let me know what you want to see changed.