### PR TITLE
audrv: add audrvVoiceIsPaused

### DIFF
--- a/nx/include/switch/audio/driver.h
+++ b/nx/include/switch/audio/driver.h
@@ -62,6 +62,7 @@ struct AudioDriverWaveBuf {
 bool audrvVoiceInit(AudioDriver* d, int id, int num_channels, PcmFormat format, int sample_rate);
 void audrvVoiceDrop(AudioDriver* d, int id);
 void audrvVoiceStop(AudioDriver* d, int id);
+bool audrvVoiceIsPaused(AudioDriver* d, int id);
 bool audrvVoiceIsPlaying(AudioDriver* d, int id);
 bool audrvVoiceAddWaveBuf(AudioDriver* d, int id, AudioDriverWaveBuf* wavebuf);
 u32 audrvVoiceGetWaveBufSeq(AudioDriver* d, int id);

--- a/nx/source/audio/voice.c
+++ b/nx/source/audio/voice.c
@@ -106,6 +106,11 @@ void audrvVoiceStop(AudioDriver* d, int id)
     _audrvVoiceResetInternalState(d, id);
 }
 
+bool audrvVoiceIsPaused(AudioDriver* d, int id)
+{
+    return d->in_voices[id].state == AudioRendererVoicePlayState_Paused && d->etc->voices[id].first_wavebuf;
+}
+
 bool audrvVoiceIsPlaying(AudioDriver* d, int id)
 {
     return d->in_voices[id].state == AudioRendererVoicePlayState_Started && d->etc->voices[id].first_wavebuf;


### PR DESCRIPTION
### Description
This pull request adds `audrvVoiceIsPaused` to libnx. I've been kind of wanting this to be a thing for a while, since libctru has `ndspChnIsPaused` as an equivalent to this.

### Hardware Test
https://streamable.com/djoa9f

### Example Code
[audren-simple-is-paused.zip](https://github.com/switchbrew/libnx/files/6378963/audren-simple-is-paused.zip)
