### PR TITLE
Update core bluetooth and hid connection event info to support all firmwares

### DIFF
--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -152,9 +152,18 @@ typedef struct {
         u8 data[0x480];                                 ///< Raw data.
 
         struct {
-            BtdrvAddress addr;                          ///< Device address.
-            u8 pad[2];                                  ///< Padding
-            BtdrvHidConnectionStatus status;            ///< \ref BtdrvHidConnectionStatus
+            union {
+                struct {
+                    BtdrvAddress addr;                  ///< Device address.
+                    u8 pad[2];                          ///< Padding
+                    BtdrvHidConnectionStatus status;    ///< \ref BtdrvHidConnectionStatus
+                } v1;                                   ///< [1.0.0-11.0.1]
+
+                struct {
+                    BtdrvHidConnectionStatus status;    ///< \ref BtdrvHidConnectionStatus
+                    BtdrvAddress addr;                  ///< Device address.
+                } v12;                                  ///< [12.0.0+]
+            };
         } connection;                                   ///< ::BtdrvHidEventType_Connection
 
         struct {

--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -90,11 +90,18 @@ typedef struct {
         struct {
             union {
                 struct {
+                    BtdrvAddress addr;                      ///< Device address.
+                    u8 pad[2];                              ///< Padding
+                    u32 status;                             ///< Status, always 0 except with ::BtdrvConnectionEventType_Status: 2 = ACL Link is now Resumed, 9 = connection failed (pairing/authentication failed, or opening the hid connection failed).
+                    u32 type;                               ///< \ref BtdrvConnectionEventType
+                } v1;                                       ///< [1.0.0-8.1.1]
+
+                struct {
                     u32 status;                             ///< Status, always 0 except with ::BtdrvConnectionEventType_Status: 2 = ACL Link is now Resumed, 9 = connection failed (pairing/authentication failed, or opening the hid connection failed).
                     BtdrvAddress addr;                      ///< Device address.
                     u8 pad[2];                              ///< Padding
                     u32 type;                               ///< \ref BtdrvConnectionEventType
-                } v1;                                       ///< [1.0.0-11.0.1]
+                } v9;                                       ///< [9.0.0-11.0.1]
 
                 struct {
                     u32 type;                               ///< \ref BtdrvConnectionEventType


### PR DESCRIPTION
As per the title. Adds missing event info definitions for firmware specific changes to the connection field of both `BtdrvEventInfo` and `BtdrvHidEventInfo` structs.