### PR TITLE
btm: add DeviceCondition definitions

### DIFF
--- a/nx/include/switch/services/btm_types.h
+++ b/nx/include/switch/services/btm_types.h
@@ -64,7 +64,7 @@ typedef enum {
 
 /// BdName
 typedef struct {
-    u8 name[0x20];             ///< Name string.
+    char name[0x20];           ///< Name string.
 } BtmBdName;
 
 /// ClassOfDevice
@@ -91,9 +91,68 @@ typedef struct {
     u8 feature_set;                       ///< Same as BtdrvAdapterProperty::feature_set.
 } BtmHostDeviceProperty;
 
-/// DeviceCondition
+/// BtmConnectedDevice
 typedef struct {
-    u8 unk_x0[0x368];             ///< Unknown
+    BtdrvAddress address;
+    u8 pad[2];
+    u32 unk_x8;
+    char name[0x20];
+    u8 unk_x2C[0x1C];
+    u16 vid;
+    u16 pid;
+    u8 unk_x4C[0x20];
+} BtmConnectedDevice;
+
+/// DeviceCondition [1.0.0-5.0.2]
+typedef struct {
+    u32 unk_x0;
+    u32 unk_x4;
+    u8 unk_x8;
+    u8 unk_x9;
+    u8 max_count;
+    u8 connected_count;
+    BtmConnectedDevice devices[8];
+} BtmDeviceConditionV100;
+
+/// DeviceCondition [5.1.0-7.0.1]
+typedef struct {
+    u32 unk_x0;
+    u32 unk_x4;
+    u8 unk_x8;
+    u8 unk_x9[2];
+    u8 max_count;
+    u8 connected_count;
+    u8 pad[3];
+    BtmConnectedDevice devices[8];
+} BtmDeviceConditionV510;
+
+/// DeviceCondition [8.0.0-8.1.1]
+typedef struct {
+    u32 unk_x0;
+    u32 unk_x4;
+    u8 unk_x8;
+    u8 unk_x9;
+    u8 max_count;
+    u8 connected_count;
+    BtmConnectedDevice devices[8];
+} BtmDeviceConditionV800;
+
+/// DeviceCondition [9.0.0+]
+typedef struct {
+    u32 unk_x0;
+    u8 unk_x4;
+    u8 unk_x5;
+    u8 max_count;
+    u8 connected_count;
+    BtmConnectedDevice devices[8];
+} BtmDeviceConditionV900;
+
+/// DeviceCondition
+typedef union {
+    BtmDeviceConditionV100 v100;
+    BtmDeviceConditionV510 v510;
+    BtmDeviceConditionV800 v800;
+    BtmDeviceConditionV900 v900;
 } BtmDeviceCondition;
 
 /// DeviceSlotMode

--- a/nx/source/services/btm.c
+++ b/nx/source/services/btm.c
@@ -157,7 +157,12 @@ Result btmAcquireDeviceConditionEvent(Event* out_event) {
 }
 
 Result btmGetDeviceCondition(BtmDeviceCondition *out) {
-    return _btmCmdOutBufPtrFixed(out, sizeof(*out), 3);
+    size_t buff_size;
+    if (hosversionAtLeast(9,0,0)) buff_size = sizeof(BtmDeviceConditionV900);
+    else if (hosversionAtLeast(8,0,0)) buff_size = sizeof(BtmDeviceConditionV800);
+    else if (hosversionAtLeast(5,1,0)) buff_size = sizeof(BtmDeviceConditionV510);
+    else buff_size = sizeof(BtmDeviceConditionV100);
+    return _btmCmdOutBufPtrFixed(out, buff_size, 3);
 }
 
 Result btmSetBurstMode(BtdrvAddress addr, bool flag) {


### PR DESCRIPTION
This adds partial definitions for BtmDeviceCondition. This structure has changed size three times over the course of various firmware updates. I wasn't sure how to best handle the different struct versions in a way that fits with the rest of the libnx codebase. Thoughts and ideas are welcome.