### PR TITLE
nxlink: only connect to host if a valid remote address has been set.

### DIFF
--- a/nx/source/runtime/nxlink.c
+++ b/nx/source/runtime/nxlink.c
@@ -7,8 +7,7 @@
 extern int __system_argc;
 extern char** __system_argv;
 
-struct in_addr __nxlink_host;
-
+struct in_addr __nxlink_host = { .s_addr = INADDR_NONE };
 
 void nxlinkSetup(void)
 {

--- a/nx/source/runtime/nxlink_stdio.c
+++ b/nx/source/runtime/nxlink_stdio.c
@@ -11,6 +11,10 @@ static int sock = -1;
 
 int nxlinkConnectToHost(bool redirStdout, bool redirStderr)
 {
+    if ((!redirStdout && !redirStderr) || __nxlink_host.s_addr == INADDR_NONE) {
+        return -1;
+    }
+
     int ret = -1;
     struct sockaddr_in srv_addr;
 


### PR DESCRIPTION
This fixes a 60+ seconds block in `connect()` whenever `nxlinkConnectToHost()` is called by the NRO sent via nxlink, but the `-s` argument isn't used.