### PR TITLE
btdrv: fix btdrvRespondToSspRequest for 12.0.0

### DIFF
--- a/nx/include/switch/services/btdrv.h
+++ b/nx/include/switch/services/btdrv.h
@@ -561,7 +561,7 @@ Result btdrvRespondToPinRequest(BtdrvAddress addr, const BtdrvPinCode *pin_code)
  * @param[in] accept Whether the request is accepted.
  * @param[in] passkey Passkey.
  */
-Result btdrvRespondToSspRequest(BtdrvAddress addr, u8 variant, bool accept, u32 passkey);
+Result btdrvRespondToSspRequest(BtdrvAddress addr, u32 variant, bool accept, u32 passkey);
 
 /**
  * @brief GetEventInfo

--- a/nx/source/services/btdrv.c
+++ b/nx/source/services/btdrv.c
@@ -311,7 +311,7 @@ Result btdrvRespondToPinRequest(BtdrvAddress addr, const BtdrvPinCode *pin_code)
     return serviceDispatchIn(&g_btdrvSrv, 13, in);
 }
 
-Result btdrvRespondToSspRequest(BtdrvAddress addr, u8 variant, bool accept, u32 passkey) {
+Result btdrvRespondToSspRequest(BtdrvAddress addr, u32 variant, bool accept, u32 passkey) {
     if (hosversionBefore(12,0,0)) {
         const struct {
             BtdrvAddress addr;
@@ -326,7 +326,7 @@ Result btdrvRespondToSspRequest(BtdrvAddress addr, u8 variant, bool accept, u32 
         const struct {
             BtdrvAddress addr;
             u8 accept;
-            u8 variant;
+            u32 variant;
             u32 passkey;
         } in = { addr, accept!=0, variant, passkey };
 


### PR DESCRIPTION
BluetoothSspVariant is 32-bit on 12.0.0. This fixes the btpair application from [nx-btred](https://github.com/plutooo/nx-btred) being unable to pair when compiled with current libnx.