### PR TITLE
hiddbg: fix IsHdlsVirtualDeviceAttached for 13.0.0

### DIFF
--- a/nx/include/switch/services/hiddbg.h
+++ b/nx/include/switch/services/hiddbg.h
@@ -415,10 +415,11 @@ Result hiddbgReleaseHdlsWorkBuffer(HiddbgHdlsSessionId session_id);
 /**
  * @brief Checks if the given device is still attached.
  * @note Only available with [7.0.0+].
+ * @param[in] session_id [13.0.0+] \ref HiddbgHdlsSessionId
  * @param[in] handle \ref HiddbgHdlsHandle
  * @param[out] out Whether the device is attached.
  */
-Result hiddbgIsHdlsVirtualDeviceAttached(HiddbgHdlsHandle handle, bool *out);
+Result hiddbgIsHdlsVirtualDeviceAttached(HiddbgHdlsSessionId session_id, HiddbgHdlsHandle handle, bool *out);
 
 /**
  * @brief Gets state for \ref HiddbgHdlsNpadAssignment.

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -508,7 +508,7 @@ Result hiddbgReleaseHdlsWorkBuffer(HiddbgHdlsSessionId session_id) {
     return rc;
 }
 
-Result hiddbgIsHdlsVirtualDeviceAttached(HiddbgHdlsHandle handle, bool *out) {
+Result hiddbgIsHdlsVirtualDeviceAttached(HiddbgHdlsSessionId session_id, HiddbgHdlsHandle handle, bool *out) {
     Result rc = 0;
 
     if (hosversionBefore(7,0,0))
@@ -517,7 +517,11 @@ Result hiddbgIsHdlsVirtualDeviceAttached(HiddbgHdlsHandle handle, bool *out) {
     if (!g_hiddbgHdlsInitialized)
         return MAKERESULT(Module_Libnx, LibnxError_NotInitialized);
 
-    rc = _hiddbgCmdNoIO(327);
+    if (hosversionBefore(13,0,0))
+        rc = _hiddbgCmdNoIO(327);
+    else
+        rc = _hiddbgCmdInU64NoOut(session_id.id, 327);
+
     if (R_FAILED(rc)) return rc;
     if (out) {
         *out = false;


### PR DESCRIPTION
`hiddbgIsHdlsVirtualDeviceAttached` makes use of the `DumpHdlsStates` ipc cmd, and args should be adapted for 13.0.0 like it was done on `hiddbgDumpHdlsStates`