### PR TITLE
hidsys: add some missing unique pad service wrappers

### DIFF
--- a/nx/include/switch/services/hidsys.h
+++ b/nx/include/switch/services/hidsys.h
@@ -1,7 +1,7 @@
 /**
  * @file hidsys.h
  * @brief hid:sys service IPC wrapper.
- * @author exelix, yellows8
+ * @author exelix, yellows8, ndeadly
  */
 #pragma once
 #include "../types.h"
@@ -43,6 +43,15 @@ typedef enum {
     HidcfgAnalogStickRotation_Clockwise90        = 1,          ///< Clockwise90
     HidcfgAnalogStickRotation_Anticlockwise90    = 2,          ///< Anticlockwise90
 } HidcfgAnalogStickRotation;
+
+/// UniquePadType
+typedef enum {
+    HidsysUniquePadType_Embedded                 = 0,          ///< Embedded
+    HidsysUniquePadType_FullKeyController        = 1,          ///< FullKeyController
+    HidsysUniquePadType_RightController          = 2,          ///< RightController
+    HidsysUniquePadType_LeftController           = 3,          ///< LeftController
+    HidsysUniquePadType_DebugPadController       = 4,          ///< DebugPadController
+} HidsysUniquePadType;
 
 /// UniquePadId for a controller.
 typedef struct {
@@ -304,6 +313,12 @@ Result hidsysGetUniquePadsFromNpad(HidNpadIdType id, HidsysUniquePadId *unique_p
 Result hidsysEnableAppletToGetInput(bool enable);
 
 /**
+ * @brief AcquireUniquePadConnectionEventHandle
+ * @param[out] out_event Output Event.
+ */
+Result hidsysAcquireUniquePadConnectionEventHandle(Event *out_event);
+
+/**
  * @brief Gets a list of all UniquePadIds.
  * @param[out] unique_pad_ids Output array of \ref HidsysUniquePadId.
  * @param[in] count Max number of entries for the unique_pad_ids array.
@@ -312,12 +327,51 @@ Result hidsysEnableAppletToGetInput(bool enable);
 Result hidsysGetUniquePadIds(HidsysUniquePadId *unique_pad_ids, s32 count, s32 *total_out);
 
 /**
+ * @brief GetUniquePadBluetoothAddress
+ * @note Only available on [3.0.0+].
+ * @param[in] unique_pad_id \ref HidsysUniquePadId
+ * @param[out] address \ref BtdrvAddress
+ */
+Result hidsysGetUniquePadBluetoothAddress(HidsysUniquePadId unique_pad_id, BtdrvAddress *address);
+
+/**
+ * @brief DisconnectUniquePad
+ * @note Only available on [3.0.0+].
+ * @param[in] unique_pad_id \ref HidsysUniquePadId
+ */
+Result hidsysDisconnectUniquePad(HidsysUniquePadId unique_pad_id);
+
+/**
+ * @brief GetUniquePadType
+ * @note Only available on [5.0.0+].
+ * @param[in] unique_pad_id \ref HidsysUniquePadId
+ * @param[out] pad_type \ref HidsysUniquePadType
+ */
+Result hidsysGetUniquePadType(HidsysUniquePadId unique_pad_id, HidsysUniquePadType *pad_type);
+
+/**
+ * @brief GetUniquePadInterface
+ * @note Only available on [5.0.0+].
+ * @param[in] unique_pad_id \ref HidsysUniquePadId
+ * @param[out] interface \ref HidNpadInterfaceType
+ */
+Result hidsysGetUniquePadInterface(HidsysUniquePadId unique_pad_id, HidNpadInterfaceType *interface);
+
+/**
  * @brief Gets the \ref HidsysUniquePadSerialNumber.
  * @note Only available on [5.0.0+].
  * @param[in] unique_pad_id \ref HidsysUniquePadId
  * @param[out] serial \ref HidsysUniquePadSerialNumber
  */
 Result hidsysGetUniquePadSerialNumber(HidsysUniquePadId unique_pad_id, HidsysUniquePadSerialNumber *serial);
+
+/**
+ * @brief GetUniquePadControllerNumber
+ * @note Only available on [5.0.0+].
+ * @param[in] unique_pad_id \ref HidsysUniquePadId
+ * @param[out] number Controller number.
+ */
+Result hidsysGetUniquePadControllerNumber(HidsysUniquePadId unique_pad_id, u64 *number);
 
 /**
  * @brief Sets the HOME-button notification LED pattern, for the specified controller.

--- a/nx/source/services/hidsys.c
+++ b/nx/source/services/hidsys.c
@@ -328,6 +328,18 @@ Result hidsysEnableAppletToGetInput(bool enable) {
     return serviceDispatchIn(&g_hidsysSrv, 503, in);
 }
 
+Result hidsysAcquireUniquePadConnectionEventHandle(Event *out_event) {
+    Handle tmp_handle = INVALID_HANDLE;
+
+    Result rc = serviceDispatch(&g_hidsysSrv, 702,
+        .out_handle_attrs = { SfOutHandleAttr_HipcCopy },
+        .out_handles = &tmp_handle,
+    );
+
+    if (R_SUCCEEDED(rc)) eventLoadRemote(out_event, tmp_handle, true);
+    return rc;
+}
+
 Result hidsysGetUniquePadIds(HidsysUniquePadId *unique_pad_ids, s32 count, s32 *total_out) {
     s64 out=0;
     Result rc = serviceDispatchOut(&g_hidsysSrv, 703, out,
@@ -338,11 +350,53 @@ Result hidsysGetUniquePadIds(HidsysUniquePadId *unique_pad_ids, s32 count, s32 *
     return rc;
 }
 
+Result hidsysGetUniquePadBluetoothAddress(HidsysUniquePadId unique_pad_id, BtdrvAddress *address) {
+    if (hosversionBefore(3,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    return serviceDispatchInOut(&g_hidsysSrv, 805, unique_pad_id, *address);
+}
+
+Result hidsysDisconnectUniquePad(HidsysUniquePadId unique_pad_id) {
+    if (hosversionBefore(3,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    return serviceDispatchIn(&g_hidsysSrv, 806, unique_pad_id);
+}
+
+Result hidsysGetUniquePadType(HidsysUniquePadId unique_pad_id, HidsysUniquePadType *pad_type) {
+    if (hosversionBefore(5,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    u64 tmp = 0;
+    Result rc = serviceDispatchInOut(&g_hidsysSrv, 807, unique_pad_id, tmp);
+    if (R_SUCCEEDED(rc)) *pad_type = (HidsysUniquePadType)tmp;
+    return rc;
+}
+
+Result hidsysGetUniquePadInterface(HidsysUniquePadId unique_pad_id, HidNpadInterfaceType *interface) {
+    if (hosversionBefore(5,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    u64 tmp = 0;
+    Result rc = serviceDispatchInOut(&g_hidsysSrv, 808, unique_pad_id, tmp);
+    if (R_SUCCEEDED(rc)) *interface = (HidNpadInterfaceType)tmp;
+    return rc;
+}
+
+
 Result hidsysGetUniquePadSerialNumber(HidsysUniquePadId unique_pad_id, HidsysUniquePadSerialNumber *serial) {
     if (hosversionBefore(5,0,0))
         return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
 
     return serviceDispatchInOut(&g_hidsysSrv, 809, unique_pad_id, *serial);
+}
+
+Result hidsysGetUniquePadControllerNumber(HidsysUniquePadId unique_pad_id, u64 *number) {
+    if (hosversionBefore(5,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    return serviceDispatchInOut(&g_hidsysSrv, 810, unique_pad_id, *number);
 }
 
 Result hidsysSetNotificationLedPattern(const HidsysNotificationLedPattern *pattern, HidsysUniquePadId unique_pad_id) {


### PR DESCRIPTION
Adds missing service wrappers for the following UniquePad functions

- AcquireUniquePadConnectionEventHandle
- GetUniquePadBluetoothAddress
- DisconnectUniquePad
- GetUniquePadType
- GetUniquePadInterface
- GetUniquePadControllerNumber