### PR TITLE
svc: Fix MemoryInfo field order

### DIFF
--- a/nx/include/switch/kernel/svc.h
+++ b/nx/include/switch/kernel/svc.h
@@ -91,8 +91,8 @@ typedef struct {
     u32 type;            ///< Memory type (see lower 8 bits of \ref MemoryState).
     u32 attr;            ///< Memory attributes (see \ref MemoryAttribute).
     u32 perm;            ///< Memory permissions (see \ref Permission).
-    u32 device_refcount; ///< Device reference count.
     u32 ipc_refcount;    ///< IPC reference count.
+    u32 device_refcount; ///< Device reference count.
     u32 padding;         ///< Padding.
 } MemoryInfo;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45773016/151661105-91cfc933-3e54-4615-a4f0-d276e5f03150.png)
Here attr has the IsDeviceMapped bit but device_refcount is 0.
See also https://github.com/Atmosphere-NX/Atmosphere/blob/master/libraries/libvapours/include/vapours/svc/svc_types_base.hpp#L23-L32