### PR TITLE
ts: Update tsGetTemperatureMilliC

### DIFF
--- a/nx/include/switch/services/ts.h
+++ b/nx/include/switch/services/ts.h
@@ -39,7 +39,7 @@ Result tsGetTemperatureRange(TsLocation location, s32 *min_temperature, s32 *max
 Result tsGetTemperature(TsLocation location, s32 *temperature);
 
 /**
- * @brief Gets the temperature for the specified \ref TsLocation, in MilliC.
+ * @brief Gets the temperature for the specified \ref TsLocation, in MilliC. [1.0.0-13.2.1]
  * @param[in] location \ref TsLocation
  * @param[out] temperature Output temperature in MilliC.
  */

--- a/nx/source/services/ts.c
+++ b/nx/source/services/ts.c
@@ -43,6 +43,8 @@ Result tsGetTemperature(TsLocation location, s32 *temperature) {
 }
 
 Result tsGetTemperatureMilliC(TsLocation location, s32 *temperature) {
+    if (hosversionAtLeast(14,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
     return _tsCmdInU8Out32(location, (u32*)temperature, 3);
 }
 


### PR DESCRIPTION
14.0.0 removed support for tsGetTemperatureMilliC.

It's reflected on switchbrew wiki.

https://switchbrew.org/wiki/PTM_services#ts