### PR TITLE
cache: need an isb barrier on icache invalidate

### DIFF
--- a/nx/source/arm/cache.s
+++ b/nx/source/arm/cache.s
@@ -88,6 +88,7 @@ armICacheInvalidate_L0:
 	bcc armICacheInvalidate_L0
 
 	dsb sy
+	isb
 
 	strb wzr, [x0, #0x104]
 


### PR DESCRIPTION
I don't have a switch but on r-pi4 it's easy to reproduce problems
without this Instruction Synchronization Barrier. Better be safe than
having "fun" dealing with super rare crashes.