### PR TITLE
Update ncm_types to 15.0.0.

### DIFF
--- a/nx/include/switch/services/ncm_types.h
+++ b/nx/include/switch/services/ncm_types.h
@@ -42,6 +42,7 @@ typedef enum {
     NcmContentMetaType_Patch                = 0x81, ///< Patch
     NcmContentMetaType_AddOnContent         = 0x82, ///< AddOnContent
     NcmContentMetaType_Delta                = 0x83, ///< Delta
+    NcmContentMetaType_DataPatch            = 0x84, ///< DataPatch
 } NcmContentMetaType;
 
 /// ContentMetaAttribute
@@ -49,6 +50,7 @@ typedef enum {
     NcmContentMetaAttribute_None                = 0,      ///< None
     NcmContentMetaAttribute_IncludesExFatDriver = BIT(0), ///< IncludesExFatDriver
     NcmContentMetaAttribute_Rebootless          = BIT(1), ///< Rebootless
+    NcmContentMetaAttribute_Compacted           = BIT(2), ///< Compacted
 } NcmContentMetaAttribute;
 
 /// ContentInstallType
@@ -86,7 +88,9 @@ typedef struct {
 /// ContentInfo
 typedef struct {
     NcmContentId content_id;     ///< \ref NcmContentId
-    u8 size[0x6];                ///< Content size.
+    u32 size_low;                ///< Content size (low).
+    u8 size_high;                ///< Content size (high).
+    u8 attr;                     ///< Content attributes.
     u8 content_type;             ///< \ref NcmContentType.
     u8 id_offset;                ///< Offset of this content. Unused by most applications.
 } NcmContentInfo;
@@ -130,12 +134,30 @@ typedef struct {
     u8 reserved[0x8];            ///< Unused.
 } NcmPatchMetaExtendedHeader;
 
-/// AddOnContentMetaExtendedHeader
+/// AddOnContentMetaExtendedHeader [15.0.0+]
+typedef struct {
+    u64 application_id;                  ///< ApplicationId of this add-on-content's corresponding application.
+    u32 required_application_version;    ///< Version of the application required by this add-on-content.
+    u8 content_accessibility_individual; ///< ContentAccessibilityIndividual.
+    u8 padding[3];                       ///< Padding.
+    u64 data_patch_id;                   ///< DataPatchId of this add-on-content's corresponding data patch.
+} NcmAddOnContentMetaExtendedHeader;
+
+/// LegacyAddOnContentMetaExtendedHeader [1.0.0-14.1.2]
 typedef struct {
     u64 application_id;               ///< ApplicationId of this add-on-content's corresponding application.
     u32 required_application_version; ///< Version of the application required by this add-on-content.
     u32 padding;                      ///< Padding.
-} NcmAddOnContentMetaExtendedHeader;
+} NcmLegacyAddOnContentMetaExtendedHeader;
+
+/// DataPatchMetaExtendedHeader
+typedef struct {
+    u64 data_id;                      ///< DataId of this data patch's corresponding add-on-content.
+    u64 application_id;               ///< ApplicationId of this data patch's add-on-content's corresponding application.
+    u32 required_application_version; ///< Version of the application required by this data patch.
+    u32 extended_data_size;           ///< Size of the extended data following the NcmContentInfos.
+    u64 padding;                      ///< Padding.
+} NcmDataPatchMetaExtendedHeader;
 
 /// SystemUpdateMetaExtendedHeader
 typedef struct {
@@ -148,3 +170,22 @@ typedef struct {
     u8 storageID;           ///< \ref NcmStorageId
     u8 pad[7];              ///< Padding
 } NcmProgramLocation;
+
+/**
+ * @brief Converts the size fields from an input \ref NcmContentInfo into a usable 64-bit integer.
+ * @param[in] info Pointer to \ref NcmContentInfo object.
+ * @param[out] out Output size.
+ */
+NX_INLINE void ncmContentInfoSizeToU64(const NcmContentInfo *info, u64 *out) {
+    *out = ((u64)info->size_high << 32) | info->size_low;
+}
+
+/**
+ * @brief Updates the size fields from a \ref NcmContentInfo using an input 64-bit integer.
+ * @param[in] size Input size.
+ * @param[out] out Pointer to \ref NcmContentInfo object to be updated.
+ */
+NX_INLINE void ncmU64ToContentInfoSize(const u64 size, NcmContentInfo *info) {
+    info->size_low = size & 0xFFFFFFFF;
+    info->size_high = (u8)(size >> 32);
+}

--- a/nx/include/switch/services/ncm_types.h
+++ b/nx/include/switch/services/ncm_types.h
@@ -176,7 +176,7 @@ typedef struct {
  * @param[in] info Pointer to \ref NcmContentInfo object.
  * @param[out] out Output size.
  */
-NX_INLINE void ncmContentInfoSizeToU64(const NcmContentInfo *info, u64 *out) {
+NX_CONSTEXPR void ncmContentInfoSizeToU64(const NcmContentInfo *info, u64 *out) {
     *out = ((u64)info->size_high << 32) | info->size_low;
 }
 
@@ -185,7 +185,7 @@ NX_INLINE void ncmContentInfoSizeToU64(const NcmContentInfo *info, u64 *out) {
  * @param[in] size Input size.
  * @param[out] out Pointer to \ref NcmContentInfo object to be updated.
  */
-NX_INLINE void ncmU64ToContentInfoSize(const u64 size, NcmContentInfo *info) {
+NX_CONSTEXPR void ncmU64ToContentInfoSize(const u64 size, NcmContentInfo *info) {
     info->size_low = size & 0xFFFFFFFF;
     info->size_high = (u8)(size >> 32);
 }

--- a/nx/include/switch/services/ncm_types.h
+++ b/nx/include/switch/services/ncm_types.h
@@ -138,7 +138,7 @@ typedef struct {
 typedef struct {
     u64 application_id;                  ///< ApplicationId of this add-on-content's corresponding application.
     u32 required_application_version;    ///< Version of the application required by this add-on-content.
-    u8 content_accessibility_individual; ///< ContentAccessibilityIndividual.
+    u8 content_accessibilities;          ///< Content accessibilities.
     u8 padding[3];                       ///< Padding.
     u64 data_patch_id;                   ///< DataPatchId of this add-on-content's corresponding data patch.
 } NcmAddOnContentMetaExtendedHeader;

--- a/nx/include/switch/services/ncm_types.h
+++ b/nx/include/switch/services/ncm_types.h
@@ -172,8 +172,8 @@ typedef struct {
 } NcmProgramLocation;
 
 /**
- * @brief Converts the size fields from an input \ref NcmContentInfo into a usable 64-bit integer.
- * @param[in] info Pointer to \ref NcmContentInfo object.
+ * @brief Retrieves the content size from a \ref NcmContentInfo struct.
+ * @param[in] info Pointer to \ref NcmContentInfo struct.
  * @param[out] out Output size.
  */
 NX_CONSTEXPR void ncmContentInfoSizeToU64(const NcmContentInfo *info, u64 *out) {
@@ -181,9 +181,9 @@ NX_CONSTEXPR void ncmContentInfoSizeToU64(const NcmContentInfo *info, u64 *out) 
 }
 
 /**
- * @brief Updates the size fields from a \ref NcmContentInfo using an input 64-bit integer.
+ * @brief Updates the content size from a \ref NcmContentInfo struct.
  * @param[in] size Input size.
- * @param[out] out Pointer to \ref NcmContentInfo object to be updated.
+ * @param[out] out Pointer to \ref NcmContentInfo struct.
  */
 NX_CONSTEXPR void ncmU64ToContentInfoSize(const u64 size, NcmContentInfo *info) {
     info->size_low = size & 0xFFFFFFFF;


### PR DESCRIPTION
* Added `NcmContentMetaType_DataPatch`.
* Added `NcmContentMetaAttribute_Compacted`.
* Updated `NcmContentInfo`:
    * Replaced `size` field with `size_low` and `size_high`, which are easier to work with.
    * Added new `attr` field.
* Updated `NcmAddOnContentMetaExtendedHeader`:
    * Added new `content_accessibilities` and `data_patch_id` fields.
* Renamed previous `NcmAddOnContentMetaExtendedHeader` to `NcmLegacyAddOnContentMetaExtendedHeader`.
* Added `NcmDataPatchMetaExtendedHeader`.
* Added `ncmContentInfoSizeToU64` and `ncmU64ToContentInfoSize` methods to easily work with size fields from `NcmContentInfo` objects.