### PR TITLE
bpc: fix GetSleepButtonState/GetPowerButton

### DIFF
--- a/nx/source/services/bpc.c
+++ b/nx/source/services/bpc.c
@@ -24,7 +24,7 @@ static Result _bpcCmdNoIO(Service *srv, u32 cmd_id) {
 }
 
 static Result _bpcCmdOutU8(Service* srv, u32 cmd_id, u8* out) {
-    return serviceDispatchOut(&g_bpcSrv, cmd_id, out);
+    return serviceDispatchOut(&g_bpcSrv, cmd_id, *out);
 }
 
 Result bpcShutdownSystem(void) {


### PR DESCRIPTION
This was not actually writing the output u8 due to typo, breaking power button detection for anything built with libnx since commit d42ddeff783ec9ae92ea38c4b7857f5c81a1bebc was included.

Note the original typo was PR'd by me.