### PR TITLE
Update console.c

### DIFF
--- a/nx/source/runtime/devices/console.c
+++ b/nx/source/runtime/devices/console.c
@@ -590,9 +590,9 @@ PrintConsole* consoleInit(PrintConsole* console) {
 		currentConsole = console;
 	} else {
 		console = currentConsole;
+		*currentConsole = defaultConsole;
 	}
-
-	*currentConsole = defaultConsole;
+	
 	if (!console->renderer) {
 		console->renderer = getDefaultConsoleRenderer();
 	}


### PR DESCRIPTION
This line needs to be inside the if statement, it being outside creates a bug which prevents the use of custom PrintConsoles, as it will force any custom PrintConsole to just be equal to the default console. It should only be ran if the default console is being used.

(I've never really contributed to any open source github projects before, so I'm not 100% sure how pull requests work, I hope I did it right)