### PR TITLE
audctl: fix TargetVolume functions

### DIFF
--- a/nx/include/switch/services/audctl.h
+++ b/nx/include/switch/services/audctl.h
@@ -41,10 +41,10 @@ Result audctlInitialize(void);
 void audctlExit(void);
 Service* audctlGetServiceSession(void);
 
-Result audctlGetTargetVolume(float* volume_out, AudioTarget target);
-Result audctlSetTargetVolume(AudioTarget target, float volume);
-Result audctlGetTargetVolumeMin(float* volume_out);
-Result audctlGetTargetVolumeMax(float* volume_out);
+Result audctlGetTargetVolume(s32* volume_out, AudioTarget target);
+Result audctlSetTargetVolume(AudioTarget target, s32 volume);
+Result audctlGetTargetVolumeMin(s32* volume_out);
+Result audctlGetTargetVolumeMax(s32* volume_out);
 Result audctlIsTargetMute(bool* mute_out, AudioTarget target);
 Result audctlSetTargetMute(AudioTarget target, bool mute);
 Result audctlIsTargetConnected(bool* connected_out, AudioTarget target);

--- a/nx/source/services/audctl.c
+++ b/nx/source/services/audctl.c
@@ -20,13 +20,13 @@ Service* audctlGetServiceSession(void) {
     return &g_audctlSrv;
 }
 
-Result audctlGetTargetVolume(float* volume_out, AudioTarget target) {
+Result audctlGetTargetVolume(s32* volume_out, AudioTarget target) {
     const struct {
         u32 target;
     } in = { target };
 
     struct {
-        float volume;
+        s32 volume;
     } out;
 
     Result rc = serviceDispatchInOut(&g_audctlSrv, 0, in, out);
@@ -37,18 +37,18 @@ Result audctlGetTargetVolume(float* volume_out, AudioTarget target) {
     return rc;
 }
 
-Result audctlSetTargetVolume(AudioTarget target, float volume) {
+Result audctlSetTargetVolume(AudioTarget target, s32 volume) {
     const struct {
         u32 target;
-        float volume;
+        s32 volume;
     } in = { target, volume };
 
     return serviceDispatchIn(&g_audctlSrv, 1, in);
 }
 
-Result audctlGetTargetVolumeMin(float* volume_out) {
+Result audctlGetTargetVolumeMin(s32* volume_out) {
     struct {
-        float volume;
+        s32 volume;
     } out;
 
     Result rc = serviceDispatchOut(&g_audctlSrv, 2, out);
@@ -59,9 +59,9 @@ Result audctlGetTargetVolumeMin(float* volume_out) {
     return rc;
 }
 
-Result audctlGetTargetVolumeMax(float* volume_out) {
+Result audctlGetTargetVolumeMax(s32* volume_out) {
     struct {
-        float volume;
+        s32 volume;
     } out;
 
     Result rc = serviceDispatchOut(&g_audctlSrv, 3, out);


### PR DESCRIPTION
These functions take a signed int, ranging from 0 to 15.
MasterVolume functions, on the other hand, take a float from 0 to 128.