### PR TITLE
hiddbg: modify hiddbgAttachHdlsWorkBuffer to accept a user-supplied buffer and size

### DIFF
--- a/nx/include/switch/services/hiddbg.h
+++ b/nx/include/switch/services/hiddbg.h
@@ -402,7 +402,7 @@ Result hiddbgUnsetAllAutoPilotVirtualPadState(void);
  * @brief Initialize Hdls.
  * @note Only available with [7.0.0+].
  * @param[out] session_id [13.0.0+] \ref HiddbgHdlsSessionId
- * @param[in] buffer An existing buffer to be used as transfer memory. If null a new transfer memory will be created.
+ * @param[in] buffer An existing buffer to be used as transfer memory.
  * @param[in] size Size of the supplied buffer.
  */
 Result hiddbgAttachHdlsWorkBuffer(HiddbgHdlsSessionId *session_id, void *buffer, size_t size);

--- a/nx/include/switch/services/hiddbg.h
+++ b/nx/include/switch/services/hiddbg.h
@@ -402,8 +402,10 @@ Result hiddbgUnsetAllAutoPilotVirtualPadState(void);
  * @brief Initialize Hdls.
  * @note Only available with [7.0.0+].
  * @param[out] session_id [13.0.0+] \ref HiddbgHdlsSessionId
+ * @param[in] buffer An existing buffer to be used as transfer memory. If null a new transfer memory will be created.
+ * @param[in] size Size of the supplied buffer.
  */
-Result hiddbgAttachHdlsWorkBuffer(HiddbgHdlsSessionId *session_id);
+Result hiddbgAttachHdlsWorkBuffer(HiddbgHdlsSessionId *session_id, void *buffer, size_t size);
 
 /**
  * @brief Exit Hdls, must be called at some point prior to \ref hiddbgExit.

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -467,7 +467,7 @@ static Result _hiddbgAttachHdlsWorkBuffer(HiddbgHdlsSessionId *session_id, Trans
         return _hiddbgCmdInTmemOutU64(tmem, &session_id->id, 324);
 }
 
-Result hiddbgAttachHdlsWorkBuffer(HiddbgHdlsSessionId *session_id) {
+Result hiddbgAttachHdlsWorkBuffer(HiddbgHdlsSessionId *session_id, void *buffer, size_t size) {
     Result rc=0;
 
     if (session_id) session_id->id = 0;
@@ -478,8 +478,10 @@ Result hiddbgAttachHdlsWorkBuffer(HiddbgHdlsSessionId *session_id) {
     if (g_hiddbgHdlsInitialized)
         return MAKERESULT(Module_Libnx, LibnxError_AlreadyInitialized);
 
-
-    rc = tmemCreate(&g_hiddbgHdlsTmem, 0x1000, Perm_Rw);
+    if (buffer==NULL)
+        rc = tmemCreate(&g_hiddbgHdlsTmem, 0x1000, Perm_Rw);
+    else
+        rc = tmemCreateFromMemory(&g_hiddbgHdlsTmem, buffer, size, Perm_Rw);
     if (R_FAILED(rc)) return rc;
 
     rc = _hiddbgAttachHdlsWorkBuffer(session_id, &g_hiddbgHdlsTmem);

--- a/nx/source/services/hiddbg.c
+++ b/nx/source/services/hiddbg.c
@@ -478,10 +478,7 @@ Result hiddbgAttachHdlsWorkBuffer(HiddbgHdlsSessionId *session_id, void *buffer,
     if (g_hiddbgHdlsInitialized)
         return MAKERESULT(Module_Libnx, LibnxError_AlreadyInitialized);
 
-    if (buffer==NULL)
-        rc = tmemCreate(&g_hiddbgHdlsTmem, 0x1000, Perm_Rw);
-    else
-        rc = tmemCreateFromMemory(&g_hiddbgHdlsTmem, buffer, size, Perm_Rw);
+    rc = tmemCreateFromMemory(&g_hiddbgHdlsTmem, buffer, size, Perm_Rw);
     if (R_FAILED(rc)) return rc;
 
     rc = _hiddbgAttachHdlsWorkBuffer(session_id, &g_hiddbgHdlsTmem);


### PR DESCRIPTION
The current version of `hiddbgAttachHdlsWorkBuffer` is incompatible with sysmodules using libstratosphere due to the libnx memory allocations in `tmemCreate`.  This modifies the existing function to create a transfer memory from an optional user-supplied buffer using `tmemCreateFromMemory` instead.

I wasn't sure whether breaking the existing API by adding the additional parameters was a good idea, but this seems like the most straightforward solution.