### PR TITLE
Audio: add helpers to query the active device

### DIFF
--- a/nx/include/switch/services/audctl.h
+++ b/nx/include/switch/services/audctl.h
@@ -17,6 +17,7 @@ typedef enum {
     AudioTarget_Headphone = 2,
     AudioTarget_Tv = 3,
     AudioTarget_UsbOutputDevice = 4,
+    AudioTarget_Bluetooth = 5,
 } AudioTarget;
 
 typedef enum {
@@ -66,3 +67,4 @@ Result audctlGetAudioOutputTargetForPlayReport(AudioTarget* target_out); ///< [3
 Result audctlNotifyHeadphoneVolumeWarningDisplayedEvent(void); ///< [3.0.0+]
 Result audctlSetSystemOutputMasterVolume(float volume); ///< [4.0.0+]
 Result audctlGetSystemOutputMasterVolume(float* volume_out); ///< [4.0.0+]
+Result audctlGetActiveOutputTarget(AudioTarget* target);

--- a/nx/include/switch/services/auddev.h
+++ b/nx/include/switch/services/auddev.h
@@ -22,4 +22,4 @@ Service* auddevGetServiceSession(void);
 Result auddevListAudioDeviceName(AudioDeviceName *DeviceNames, s32 max_names, s32 *total_names);
 Result auddevSetAudioDeviceOutputVolume(const AudioDeviceName *DeviceName, float volume);
 Result auddevGetAudioDeviceOutputVolume(const AudioDeviceName *DeviceName, float *volume);
-
+Result auddevGetActiveAudioDeviceName(AudioDeviceName *DeviceName);

--- a/nx/source/services/audctl.c
+++ b/nx/source/services/audctl.c
@@ -340,3 +340,19 @@ Result audctlGetSystemOutputMasterVolume(float* volume_out) {
     }
     return rc;
 }
+
+Result audctlGetActiveOutputTarget(AudioTarget* target) {
+    if (hosversionBefore(13,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    struct {
+        u32 target;
+    } out;
+
+    Result rc = serviceDispatchOut(&g_audctlSrv, 32, out);
+
+    if (R_SUCCEEDED(rc)) {
+        *target = out.target;
+    }
+    return rc;
+}

--- a/nx/source/services/auddev.c
+++ b/nx/source/services/auddev.c
@@ -62,3 +62,11 @@ Result auddevGetAudioDeviceOutputVolume(const AudioDeviceName *DeviceName, float
         .buffers = { { DeviceName, sizeof(AudioDeviceName) } },
     );
 }
+
+Result auddevGetActiveAudioDeviceName(AudioDeviceName *DeviceName) {
+    bool new_cmd = hosversionAtLeast(3,0,0);
+    return serviceDispatch(&g_auddevIAudioDevice, new_cmd==0 ? 3 : 10,
+        .buffer_attrs = { (new_cmd==0 ? SfBufferAttr_HipcMapAlias : SfBufferAttr_HipcAutoSelect) | SfBufferAttr_Out },
+        .buffers = { { DeviceName, sizeof(AudioDeviceName) } },
+    );
+}


### PR DESCRIPTION
`auddevGetActiveAudioDeviceName` does not distinguish between jack and bluetooth connected headphones, however `audctlGetActiveOutputTarget` was only added by 13.0 (with bluetooth audio functionality).