### PR TITLE
Added some definitions to /sys/socket.h

### DIFF
--- a/nx/external/bsd/include/sys/socket.h
+++ b/nx/external/bsd/include/sys/socket.h
@@ -437,11 +437,20 @@ struct cmsghdr {
 /* followed by	u_char  cmsg_data[]; */
 };
 
-// socket credential stuff, we don't need this
-// cmsg macros, uses some obscure macro
+#define	_ALIGNBYTES		(sizeof(long) - 1)
+#define	_ALIGN(p)		(((unsigned long)(p) + _ALIGNBYTES) & ~_ALIGNBYTES)
 
-#define __ALIGNBYTES32 (sizeof(__uint32_t) - 1)
-#define __ALIGN32(p)   ((__size_t)((char *)(__size_t)(p) + __ALIGNBYTES32) &~ __ALIGNBYTES32)
+/* given pointer to struct cmsghdr, return pointer to data */
+#define	CMSG_DATA(cmsg) \
+	((unsigned char *)(cmsg) + _ALIGN(sizeof(struct cmsghdr)))
+
+/* given pointer to struct cmsghdr, return pointer to next cmsghdr */
+#define	CMSG_NXTHDR(mhdr, cmsg)	\
+	(((char *)(cmsg) + _ALIGN((cmsg)->cmsg_len) + \
+			    _ALIGN(sizeof(struct cmsghdr)) > \
+	    ((char *)(mhdr)->msg_control) + (mhdr)->msg_controllen) ? \
+	    (struct cmsghdr *)NULL : \
+	    (struct cmsghdr *)((char *)(cmsg) + _ALIGN((cmsg)->cmsg_len)))
 
 /*
  * RFC 2292 requires to check msg_controllen, in case that the kernel returns
@@ -452,17 +461,11 @@ struct cmsghdr {
 	 (struct cmsghdr *)(mhdr)->msg_control : \
 	 (struct cmsghdr *)NULL)
 
+/* Length of the contents of a control message of length len */
+#define	CMSG_LEN(len)	(_ALIGN(sizeof(struct cmsghdr)) + (len))
 
-/*
- * Given pointer to struct cmsghdr, return pointer to next cmsghdr
- * RFC 2292 says that CMSG_NXTHDR(mhdr, NULL) is equivalent to CMSG_FIRSTHDR(mhdr)
- */
-#define	CMSG_NXTHDR(mhdr, cmsg)	\
-	(((char *)(cmsg) + __ALIGN32((cmsg)->cmsg_len) + \
-			    __ALIGN32(sizeof(struct cmsghdr)) > \
-	    ((char *)(mhdr)->msg_control) + (mhdr)->msg_controllen) ? \
-	    (struct cmsghdr *)NULL : \
-	    (struct cmsghdr *)((char *)(cmsg) + __ALIGN32((cmsg)->cmsg_len)))
+/* Length of the space taken up by a padded control message of length len */
+#define	CMSG_SPACE(len)	(_ALIGN(sizeof(struct cmsghdr)) + _ALIGN(len))
 
 /* "Socket"-level control message types: */
 #define	SCM_RIGHTS	0x01		/* access rights (array of int) */


### PR DESCRIPTION
Latest version of Moonlight-common-c library uses this definitions, so it is impossible to compile app without them.

To be honest I am not fully understand what they are doing, I've just copy-pasted them from Apple's /sys/socket.h file with some changes, cause it uses some Darwin types which of course not presented on Switch.

Anyway after these changes I was able to compile Moonlight it it worked perfectly.