### PR TITLE
applet: add appletGetMessageEvent

### DIFF
--- a/nx/include/switch/services/applet.h
+++ b/nx/include/switch/services/applet.h
@@ -2690,6 +2690,11 @@ Result appletSetHandlingHomeButtonShortPressedEnabled(bool flag);
 AppletInfo *appletGetAppletInfo(void);
 
 /**
+ * @brief Gets the event associated with notification messages.
+ */
+Event *appletGetMessageEvent(void);
+
+/**
  * @brief Gets a notification message, see \ref AppletMessage.
  */
 Result appletGetMessage(u32 *msg);

--- a/nx/source/services/applet.c
+++ b/nx/source/services/applet.c
@@ -2988,6 +2988,10 @@ AppletInfo *appletGetAppletInfo(void) {
     return &g_appletInfo;
 }
 
+Event *appletGetMessageEvent(void) {
+    return &g_appletMessageEvent;
+}
+
 Result appletGetMessage(u32 *msg) {
     Result rc=0;
     if (msg==NULL) return MAKERESULT(Module_Libnx, LibnxError_BadInput);


### PR DESCRIPTION
This allows waiting for applet messages using a custom event loop (as opposed to using appletMainLoop).