### PR TITLE
usbcomms: API improvements

### DIFF
--- a/nx/include/switch/runtime/devices/usb_comms.h
+++ b/nx/include/switch/runtime/devices/usb_comms.h
@@ -18,7 +18,7 @@ typedef struct {
 Result usbCommsInitialize(void);
 
 /// Initializes usbComms with a specific number of interfaces.
-Result usbCommsInitializeEx(u32 num_interfaces, const UsbCommsInterfaceInfo *infos);
+Result usbCommsInitializeEx(u32 num_interfaces, const UsbCommsInterfaceInfo *infos, u16 idVendor, u16 idProduct);
 
 /// Exits usbComms.
 void usbCommsExit(void);

--- a/nx/include/switch/runtime/devices/usb_comms.h
+++ b/nx/include/switch/runtime/devices/usb_comms.h
@@ -26,6 +26,9 @@ void usbCommsExit(void);
 /// Sets whether to throw a fatal error in usbComms{Read/Write}* on failure, or just return the transferred size. By default (false) the latter is used.
 void usbCommsSetErrorHandling(bool flag);
 
+///@name Synchronous API
+///@{
+
 /// Read data with the default interface.
 size_t usbCommsRead(void* buffer, size_t size);
 
@@ -37,3 +40,31 @@ size_t usbCommsReadEx(void* buffer, size_t size, u32 interface);
 
 /// Same as usbCommsWrite except with the specified interface.
 size_t usbCommsWriteEx(const void* buffer, size_t size, u32 interface);
+
+///@}
+
+///@name Asynchronous API
+///@{
+
+/// Retrieve event used for read completion with the given interface.
+Event *usbCommsGetReadCompletionEvent(u32 interface);
+
+/// Start an asynchronous read. The completion event will be signaled when the read completes.
+/// The buffer must be page-aligned and no larger than one page.
+Result usbCommsReadAsync(void *buffer, size_t size, u32 *urbId, u32 interface);
+
+/// Complete an asynchronous read, clearing the completion event, and return the amount of data which was read.
+Result usbCommsGetReadResult(u32 urbId, u32 *transferredSize, u32 interface);
+
+
+/// Retrieve event used for write completion with the given interface.
+Event *usbCommsGetWriteCompletionEvent(u32 interface);
+
+/// Start an asynchronous write. The completion event will be signaled when the write completes.
+/// The buffer must be page-aligned and no larger than one page.
+Result usbCommsWriteAsync(void *buffer, size_t size, u32 *urbId, u32 interface);
+
+/// Complete an asynchronous write, clearing the completion event, and return the amount of data which was written.
+Result usbCommsGetWriteResult(u32 urbId, u32 *transferredSize, u32 interface);
+
+///@}

--- a/nx/source/runtime/devices/usb_comms.c
+++ b/nx/source/runtime/devices/usb_comms.c
@@ -42,7 +42,7 @@ static void _usbCommsUpdateInterfaceDescriptor(struct usb_interface_descriptor *
     }
 }
 
-Result usbCommsInitializeEx(u32 num_interfaces, const UsbCommsInterfaceInfo *infos)
+Result usbCommsInitializeEx(u32 num_interfaces, const UsbCommsInterfaceInfo *infos, u16 idVendor, u16 idProduct)
 {
     Result rc = 0;
     rwlockWriteLock(&g_usbCommsLock);
@@ -76,8 +76,8 @@ Result usbCommsInitializeEx(u32 num_interfaces, const UsbCommsInterfaceInfo *inf
                     .bDeviceSubClass = 0x00,
                     .bDeviceProtocol = 0x00,
                     .bMaxPacketSize0 = 0x40,
-                    .idVendor = 0x057e,
-                    .idProduct = 0x3000,
+                    .idVendor = idVendor,
+                    .idProduct = idProduct,
                     .bcdDevice = 0x0100,
                     .iManufacturer = iManufacturer,
                     .iProduct = iProduct,
@@ -157,7 +157,7 @@ Result usbCommsInitializeEx(u32 num_interfaces, const UsbCommsInterfaceInfo *inf
 
 Result usbCommsInitialize(void)
 {
-    return usbCommsInitializeEx(1, NULL);
+    return usbCommsInitializeEx(1, NULL, 0x057e, 0x3000);
 }
 
 static void _usbCommsInterfaceFree(usbCommsInterface *interface)


### PR DESCRIPTION
This adds an asynchronous API to usbComms with minimal error handling, for use as an alternative to the blocking versions. This also enables setting the VID:PID reported by the device during initialization.