### PR TITLE
default_window: fix missing weak declarations

### DIFF
--- a/nx/source/display/default_window.c
+++ b/nx/source/display/default_window.c
@@ -17,7 +17,7 @@ NWindow* nwindowGetDefault(void)
     return &g_defaultWin;
 }
 
-void __nx_win_init(void)
+void __attribute__((weak)) __nx_win_init(void)
 {
     Result rc;
     rc = viInitialize(ViServiceType_Default);
@@ -45,7 +45,7 @@ void __nx_win_init(void)
         diagAbortWithResult(MAKERESULT(Module_Libnx, LibnxError_BadGfxInit));
 }
 
-void __nx_win_exit(void)
+void __attribute__((weak)) __nx_win_exit(void)
 {
     nwindowClose(&g_defaultWin);
     viCloseLayer(&g_viLayer);


### PR DESCRIPTION
These were clearly intended to be overridable, but weren't since they weren't declared weak at the definition.
```
libnx.a(default_window.o): in function `__nx_win_init':
default_window.c:(.text.__nx_win_init+0x0): multiple definition of `__nx_win_init'
main.o:main.cpp:(.text.__nx_win_init+0x0): first defined here
```

https://github.com/switchbrew/libnx/blob/dca4fb772aabf24c680561337f6bdffa69d7eb9a/nx/source/runtime/init.c#L101
https://github.com/switchbrew/libnx/blob/dca4fb772aabf24c680561337f6bdffa69d7eb9a/nx/source/runtime/init.c#L152