### PR TITLE
Use one other thing than the system Language with nacpGetLanguageEntry

### DIFF
--- a/nx/include/switch/nacp.h
+++ b/nx/include/switch/nacp.h
@@ -92,3 +92,7 @@ typedef struct {
 /// If you're using ns you may want to use \ref nsGetApplicationDesiredLanguage instead.
 Result nacpGetLanguageEntry(NacpStruct* nacp, NacpLanguageEntry** langentry);
 
+
+//Same thank nacpGetLanguageEntry, except this uses the input languageChoosen instead of the system language.
+Result nacpGetLanguageEntrySpecialLanguage(NacpStruct* nacp, NacpLanguageEntry** langentry, const u32 languageChoosen);
+

--- a/nx/source/runtime/nacp.c
+++ b/nx/source/runtime/nacp.c
@@ -74,3 +74,46 @@ Result nacpGetLanguageEntry(NacpStruct* nacp, NacpLanguageEntry** langentry) {
     return rc;
 }
 
+Result nacpGetLanguageEntrySpecialLanguage(NacpStruct* nacp, NacpLanguageEntry** langentry, const u32 languageChoosen) {
+    Result rc=0;
+    SetLanguage Language= languageChoosen;
+    NacpLanguageEntry *entry = NULL;
+    u32 i=0;
+
+    if (nacp==NULL || langentry==NULL)
+        return MAKERESULT(Module_Libnx, LibnxError_BadInput);
+
+    *langentry = NULL;
+
+    rc = setInitialize();
+    if (R_FAILED(rc))
+        return rc;
+
+    if (Language < 0)
+        rc = MAKERESULT(Module_Libnx, LibnxError_BadInput);
+
+    if (R_SUCCEEDED(rc) && Language >= 15)
+        Language = SetLanguage_ENUS;//Use ENUS for unsupported system languages.
+
+    setExit();
+
+    if (R_FAILED(rc))
+        return rc;
+
+    entry = &nacp->lang[g_nacpLanguageTable[Language]];
+
+    if (entry->name[0]==0 && entry->author[0]==0) {
+        for(i=0; i<16; i++) {
+            entry = &nacp->lang[i];
+            if (entry->name[0] || entry->author[0]) break;
+        }
+    }
+
+    if (entry->name[0]==0 && entry->author[0]==0)
+        return rc;
+
+    *langentry = entry;
+
+    return rc;
+}
+

--- a/nx/source/runtime/nacp.c
+++ b/nx/source/runtime/nacp.c
@@ -74,7 +74,7 @@ Result nacpGetLanguageEntry(NacpStruct* nacp, NacpLanguageEntry** langentry) {
     return rc;
 }
 
-Result nacpGetLanguageEntrySpecialLanguage(NacpStruct* nacp, NacpLanguageEntry** langentry, const u32 languageChoosen) {
+Result nacpGetLanguageEntrySpecialLanguage(NacpStruct* nacp, NacpLanguageEntry** langentry, const SetLanguage languageChoosen) {
     Result rc=0;
     SetLanguage Language= languageChoosen;
     NacpLanguageEntry *entry = NULL;


### PR DESCRIPTION
Hi, I have to fetch all titles installed on my switch for my homebrew [SimpleModDownloader](https://github.com/PoloNX/SimpleModDownloader)

But If I do one request with one jap/chinese name it wont works so I want to get the name of one game directly with one specific languages (en-US here) 