### PR TITLE
service: nfc: Add mifare guard

### DIFF
--- a/nx/source/services/nfc.c
+++ b/nx/source/services/nfc.c
@@ -102,6 +102,8 @@ void _nfcCleanup(void) {
     serviceClose(&g_nfcSrv);
 }
 
+NX_GENERATE_SERVICE_GUARD(nfcMf);
+
 Result _nfcMfInitialize() {
     Result rc = MAKERESULT(Module_Libnx, LibnxError_BadInput);
 


### PR DESCRIPTION
Missed this function in previous commit. Mifare should be functional now.