### PR TITLE
service: Static assert arguments aren't pointers to prevent failure-to-deref

### DIFF
--- a/nx/source/services/capsc.c
+++ b/nx/source/services/capsc.c
@@ -109,7 +109,7 @@ Result capscGenerateApplicationAlbumEntry(CapsApplicationAlbumEntry *appEntry, c
 Result capscSaveAlbumScreenShotFile(const CapsAlbumFileId *file_id, const void* buffer, u64 buffer_size) {
     if (hosversionBefore(2,0,0) || hosversionAtLeast(4,0,0))
         return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
-    return serviceDispatchIn(&g_capscSrv, 2201, file_id,
+    return serviceDispatchIn(&g_capscSrv, 2201, *file_id,
         .buffer_attrs = { SfBufferAttr_HipcMapTransferAllowsNonSecure | SfBufferAttr_HipcMapAlias | SfBufferAttr_In },
         .buffers = { { buffer, buffer_size }, },
     );

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -60,13 +60,17 @@ NX_INLINE Result _fsObjectDispatchImpl(
     _fsObjectDispatchImpl((_s),(_rid),NULL,0,NULL,0,(SfDispatchParams){ __VA_ARGS__ })
 
 #define _fsObjectDispatchIn(_s,_rid,_in,...) \
-    _fsObjectDispatchImpl((_s),(_rid),&(_in),sizeof(_in),NULL,0,(SfDispatchParams){ __VA_ARGS__ })
+    ({ _Static_assert(!(serviceMacroDetectIsPointer(_in))); \
+    _fsObjectDispatchImpl((_s),(_rid),&(_in),sizeof(_in),NULL,0,(SfDispatchParams){ __VA_ARGS__ }); })
 
 #define _fsObjectDispatchOut(_s,_rid,_out,...) \
-    _fsObjectDispatchImpl((_s),(_rid),NULL,0,&(_out),sizeof(_out),(SfDispatchParams){ __VA_ARGS__ })
+    ({ _Static_assert(!(serviceMacroDetectIsPointer(_out))); \
+    _fsObjectDispatchImpl((_s),(_rid),NULL,0,&(_out),sizeof(_out),(SfDispatchParams){ __VA_ARGS__ }); })
 
 #define _fsObjectDispatchInOut(_s,_rid,_in,_out,...) \
-    _fsObjectDispatchImpl((_s),(_rid),&(_in),sizeof(_in),&(_out),sizeof(_out),(SfDispatchParams){ __VA_ARGS__ })
+    ({ _Static_assert(!(serviceMacroDetectIsPointer(_in))); \
+    _Static_assert(!(serviceMacroDetectIsPointer(_out))); \
+    _fsObjectDispatchImpl((_s),(_rid),&(_in),sizeof(_in),&(_out),sizeof(_out),(SfDispatchParams){ __VA_ARGS__ }); })
 
 NX_GENERATE_SERVICE_GUARD(fs);
 

--- a/nx/source/services/ns.c
+++ b/nx/source/services/ns.c
@@ -1503,7 +1503,7 @@ Result nsCompareApplicationDeliveryInfo(const NsApplicationDeliveryInfo *info0, 
     Service srv={0};
     Result rc = nsGetApplicationManagerInterface(&srv);
 
-    if (R_SUCCEEDED(rc)) rc = serviceDispatchOut(&srv, 2005, out,
+    if (R_SUCCEEDED(rc)) rc = serviceDispatchOut(&srv, 2005, *out,
         .buffer_attrs = {
             SfBufferAttr_HipcMapAlias | SfBufferAttr_In,
             SfBufferAttr_HipcMapAlias | SfBufferAttr_In,
@@ -1710,7 +1710,7 @@ Result nsCompareSystemDeliveryInfo(const NsSystemDeliveryInfo *info0, const NsSy
     Service srv={0};
     Result rc = nsGetApplicationManagerInterface(&srv);
 
-    if (R_SUCCEEDED(rc)) rc = serviceDispatchOut(&srv, 2015, out,
+    if (R_SUCCEEDED(rc)) rc = serviceDispatchOut(&srv, 2015, *out,
         .buffer_attrs = {
             SfBufferAttr_HipcMapAlias | SfBufferAttr_In,
             SfBufferAttr_HipcMapAlias | SfBufferAttr_In,


### PR DESCRIPTION
I got very frustrated just now by failing to dereference an output pointer argument, so I added a static assertion that the input/output to the service dispatch macros aren't pointers.

This immediately caught three cases where we failed to invoke dispatch function correctly, so this also fixes those.