### PR TITLE
crypto: fix aes-cbc individual block decryption

### DIFF
--- a/nx/source/crypto/aes_cbc.c
+++ b/nx/source/crypto/aes_cbc.c
@@ -261,8 +261,9 @@ static inline void _aes128CbcDecryptBlocks(Aes128CbcContext *ctx, u8 *dst_u8, co
               AES_ENC_DEC_INPUT_ROUND_KEY(10)
         );
 
-        /* Update IV. */
-        cur_iv = tmp0;
+        /* Do XOR for CBC. */
+        tmp0 = veorq_u8(tmp0, cur_iv);
+        cur_iv = block0;
 
         /* Store to output. */
         vst1q_u8(dst_u8, tmp0);
@@ -478,8 +479,9 @@ static inline void _aes192CbcDecryptBlocks(Aes192CbcContext *ctx, u8 *dst_u8, co
               AES_ENC_DEC_INPUT_ROUND_KEY(12)
         );
 
-        /* Update IV. */
-        cur_iv = tmp0;
+        /* Do XOR for CBC. */
+        tmp0 = veorq_u8(tmp0, cur_iv);
+        cur_iv = block0;
 
         /* Store to output. */
         vst1q_u8(dst_u8, tmp0);
@@ -711,8 +713,9 @@ static inline void _aes256CbcDecryptBlocks(Aes256CbcContext *ctx, u8 *dst_u8, co
               AES_ENC_DEC_INPUT_ROUND_KEY(14)
         );
 
-        /* Update IV. */
-        cur_iv = tmp0;
+        /* Do XOR for CBC. */
+        tmp0 = veorq_u8(tmp0, cur_iv);
+        cur_iv = block0;
 
         /* Store to output. */
         vst1q_u8(dst_u8, tmp0);


### PR DESCRIPTION
We ran into this issue in nxdumptool when decrypting the card header encryption target data from an inserted gamecard, which made us think that Nintendo added a [new field to the data](https://github.com/DarkMatterCore/nxdumptool/blob/8f75b6b923126fa3b1e7c72bbf6dcc94f3beefc9/include/core/gamecard.h#L195).

This happens due to a missing XOR operation during individual block decryption. Since the card header encryption target data is 0x70 bytes in the size, the first six blocks are decrypted correctly, while the last block is not.