### PR TITLE
svc: fix query/insecure names

### DIFF
--- a/nx/include/switch/kernel/svc.h
+++ b/nx/include/switch/kernel/svc.h
@@ -41,7 +41,7 @@ typedef enum {
     MemType_CodeReadOnly=0x14,        ///< Mapped in kernel during \ref svcControlCodeMemory.
     MemType_CodeWritable=0x15,        ///< Mapped in kernel during \ref svcControlCodeMemory.
     MemType_Coverage=0x16,            ///< Not available.
-    MemType_Insecure=0x17,            ///< Mapped in kernel during \ref svcMapInsecureMemory.
+    MemType_Insecure=0x17,            ///< Mapped in kernel during \ref svcMapInsecurePhysicalMemory.
 } MemoryType;
 
 /// Memory state bitmasks.
@@ -1118,14 +1118,14 @@ Result svcQueryPhysicalAddress(PhysicalMemoryInfo *out, u64 virtaddr);
  * @warning This is a privileged syscall. Use \ref envIsSyscallHinted to check if it is available.
  * @warning Only exists on [10.0.0+]. For older versions use \ref svcLegacyQueryIoMapping.
  */
-Result svcQueryIoMapping(u64* virtaddr, u64* out_size, u64 physaddr, u64 size);
+Result svcQueryMemoryMapping(u64* virtaddr, u64* out_size, u64 physaddr, u64 size);
 
 /**
  * @brief Returns a virtual address mapped to a given IO range.
  * @return Result code.
  * @note Syscall number 0x55.
  * @warning This is a privileged syscall. Use \ref envIsSyscallHinted to check if it is available.
- * @warning Only exists on [1.0.0-9.2.0]. For newer versions use \ref svcQueryIoMapping.
+ * @warning Only exists on [1.0.0-9.2.0]. For newer versions use \ref svcQueryMemoryMapping.
  */
 Result svcLegacyQueryIoMapping(u64* virtaddr, u64 physaddr, u64 size);
 
@@ -1580,13 +1580,13 @@ void svcCallSecureMonitor(SecmonArgs* regs);
  * @return Result code.
  * @note Syscall number 0x90.
  */
-Result svcMapInsecureMemory(void *address, u64 size);
+Result svcMapInsecurePhysicalMemory(void *address, u64 size);
 
 /**
  * @brief Undoes the effects of \ref svcMapInsecureMemory. [15.0.0+]
  * @return Result code.
  * @note Syscall number 0x91.
  */
-Result svcUnmapInsecureMemory(void *address, u64 size);
+Result svcUnmapInsecurePhysicalMemory(void *address, u64 size);
 
 ///@}

--- a/nx/source/kernel/svc.s
+++ b/nx/source/kernel/svc.s
@@ -514,7 +514,7 @@ SVC_BEGIN svcQueryPhysicalAddress
 	ret
 SVC_END
 
-SVC_BEGIN svcQueryIoMapping
+SVC_BEGIN svcQueryMemoryMapping
 	stp x0, x1, [sp, #-16]!
 	svc 0x55
 	ldp x3, x4, [sp], #16
@@ -799,12 +799,12 @@ SVC_BEGIN svcCallSecureMonitor
 	ret
 SVC_END
 
-SVC_BEGIN svcMapInsecureMemory
+SVC_BEGIN svcMapInsecurePhysicalMemory
 	svc 0x90
 	ret
 SVC_END
 
-SVC_BEGIN svcUnmapInsecureMemory
+SVC_BEGIN svcUnmapInsecurePhysicalMemory
 	svc 0x91
 	ret
 SVC_END


### PR DESCRIPTION
This fixes the names for svc::QueryMemoryMapping, svc::MapInsecurePhysicalMemory, svc::UnmapInsecurePhysicalMemory