### PR TITLE
Implement FS "ChallengeCardExistence" and "GetGameCardDeviceCertificate"

### DIFF
--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -643,7 +643,9 @@ Result fsDeviceOperatorGetMmcExtendedCsd(FsDeviceOperator* d, void* dst, size_t 
 Result fsDeviceOperatorIsGameCardInserted(FsDeviceOperator* d, bool* out);
 Result fsDeviceOperatorGetGameCardHandle(FsDeviceOperator* d, FsGameCardHandle* out);
 Result fsDeviceOperatorGetGameCardAttribute(FsDeviceOperator* d, const FsGameCardHandle* handle, u8 *out);
+Result fsDeviceOperatorGetGameCardDeviceCertificate(FsDeviceOperator* d, const FsGameCardHandle* handle, void* dst, size_t dst_size, s64 size);
 Result fsDeviceOperatorGetGameCardIdSet(FsDeviceOperator* d, void* dst, size_t dst_size, s64 size);
 Result fsDeviceOperatorGetGameCardErrorReportInfo(FsDeviceOperator* d, FsGameCardErrorReportInfo* out);
 Result fsDeviceOperatorGetGameCardDeviceId(FsDeviceOperator* d, void* dst, size_t dst_size, s64 size);
+Result fsDeviceOperatorChallengeCardExistence(FsDeviceOperator* d, const FsGameCardHandle* handle, void* dst, size_t dst_size, void* seed, size_t seed_size, void* value, size_t value_size);
 void fsDeviceOperatorClose(FsDeviceOperator* d);

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -1222,6 +1222,17 @@ Result fsDeviceOperatorGetGameCardAttribute(FsDeviceOperator* d, const FsGameCar
     return _fsObjectDispatchInOut(&d->s, 205, *handle, *out);
 }
 
+Result fsDeviceOperatorGetGameCardDeviceCertificate(FsDeviceOperator* d, const FsGameCardHandle* handle, void* dst, size_t dst_size, s64 size) {
+    const struct {
+        FsGameCardHandle handle;
+        s64 buffer_size;
+    } in = { *handle, size };
+    
+    return _fsObjectDispatchIn(&d->s, 206, in,
+        .buffer_attrs = { SfBufferAttr_HipcMapAlias | SfBufferAttr_Out },
+        .buffers = { { dst, dst_size } });
+}
+
 Result fsDeviceOperatorGetGameCardIdSet(FsDeviceOperator* d, void* dst, size_t dst_size, s64 size) {
     return _fsCmdInSizeOutBuffer(&d->s, dst, dst_size, size, 208);
 }
@@ -1236,6 +1247,24 @@ Result fsDeviceOperatorGetGameCardDeviceId(FsDeviceOperator* d, void* dst, size_
     if (hosversionBefore(3,0,0))
         return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
     return _fsCmdInSizeOutBuffer(&d->s, dst, dst_size, size, 218);
+}
+
+Result fsDeviceOperatorChallengeCardExistence(FsDeviceOperator* d, const FsGameCardHandle* handle, void* dst, size_t dst_size, void* seed, size_t seed_size, void* value, size_t value_size) {
+    if (hosversionBefore(8,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+    
+    return _fsObjectDispatchIn(&d->s, 219, *handle,
+        .buffer_attrs = {
+            SfBufferAttr_HipcMapAlias | SfBufferAttr_Out,
+            SfBufferAttr_HipcMapAlias | SfBufferAttr_In,
+            SfBufferAttr_HipcMapAlias | SfBufferAttr_In,
+        },
+        .buffers = {
+            { dst,   dst_size   },
+            { seed,  seed_size  },
+            { value, value_size },
+        },
+    );
 }
 
 void fsDeviceOperatorClose(FsDeviceOperator* d) {


### PR DESCRIPTION
Example usage:

```c
int main(int argc, char *argv[])
{
    consoleInit(NULL);

    PadState pad;
    padConfigureInput(1, HidNpadStyleSet_NpadStandard);
    padInitializeDefault(&pad);

    nsInitialize();
    fsInitialize();

    FsDeviceOperator deviceOperator;
    fsOpenDeviceOperator(&deviceOperator);

    FsGameCardHandle gcHandle = {-1};
    fsDeviceOperatorGetGameCardHandle(&deviceOperator, &gcHandle);

    u8 cert[0x200]; // output
    fsDeviceOperatorGetGameCardDeviceCertificate(&deviceOperator, &gcHandle, cert, sizeof(cert), sizeof(cert));


    // From application authentication /v%i/challenge endpoint (AAuth, used to authenticate gamecards, they can complete a proprietary challenge to prove they are legit)
    u8 seed[15] = {...};
    u8 value[16] = {...};
    u8 challenge[0x58]; // output
    fsDeviceOperatorChallengeCardExistence(&deviceOperator, &gcHandle,
                                                challenge, sizeof(challenge),
                                                seed, sizeof(seed),
                                                value, sizeof(value));


    fsDeviceOperatorClose(&deviceOperator);
    fsExit();

    nsEnsureGameCardAccess();
    nsExit();

    consoleExit(NULL);
    return 0;
}
```