### PR TITLE
Add NX_ prefix to PACKED, NORETURN, IGNORE_ARG and DEPRECATED macros

### DIFF
--- a/nx/include/switch/applets/error.h
+++ b/nx/include/switch/applets/error.h
@@ -111,7 +111,7 @@ typedef struct {
     u64 languageCode;                 ///< See set.h.
     char dialogMessage[0x800];        ///< UTF-8 Dialog message.
     char fullscreenMessage[0x800];    ///< UTF-8 Fullscreen message (displayed when the user clicks on "Details").
-} PACKED ErrorApplicationArg;
+} NX_PACKED ErrorApplicationArg;
 
 /// Error application config.
 typedef struct {

--- a/nx/include/switch/applets/swkbd.h
+++ b/nx/include/switch/applets/swkbd.h
@@ -116,7 +116,7 @@ typedef struct {
     u32 buffer_size;      ///< 0x1000-byte aligned buffer size.
     u64 entries[0x18];
     u16 total_entries;
-} PACKED SwkbdCustomizedDictionarySet;
+} NX_PACKED SwkbdCustomizedDictionarySet;
 
 /// Base swkbd arg struct.
 typedef struct {

--- a/nx/include/switch/applets/web.h
+++ b/nx/include/switch/applets/web.h
@@ -95,21 +95,21 @@ typedef struct {
     u32 pad;                     ///< Padding
     char lastUrl[0x1000];        ///< LastUrl string
     u64 lastUrlSize;             ///< Size of LastUrl, including NUL-terminator.
-} PACKED WebCommonReturnValue;
+} NX_PACKED WebCommonReturnValue;
 
 /// Header struct at offset 0 in the web Arg storage (non-webWifi).
 typedef struct {
     u16 total_entries;     ///< Total \ref WebArgTLV entries following this struct.
     u16 pad;               ///< Padding
     WebShimKind shimKind;  ///< ShimKind
-} PACKED WebArgHeader;
+} NX_PACKED WebArgHeader;
 
 /// Web TLV used in the web Arg storage.
 typedef struct {
     u16 type;       ///< Type of this arg.
     u16 size;       ///< Size of the arg data following this struct.
     u8 pad[4];      ///< Padding
-} PACKED WebArgTLV;
+} NX_PACKED WebArgTLV;
 
 /// Config struct for web applets, non-WebWifi.
 typedef struct {
@@ -133,7 +133,7 @@ typedef struct {
     u8 visible;
     u16 unk_x5;
     u8 unk_x7;
-} PACKED WebBootFooterButtonEntry;
+} NX_PACKED WebBootFooterButtonEntry;
 
 /// StorageHandleQueue
 typedef struct {

--- a/nx/include/switch/display/buffer_producer.h
+++ b/nx/include/switch/display/buffer_producer.h
@@ -11,7 +11,7 @@ typedef struct {
 } BqRect;
 
 typedef struct {
-    struct { s64 timestamp; } PACKED;
+    struct { s64 timestamp; } NX_PACKED;
     s32 isAutoTimestamp;
     BqRect crop;
     s32 scalingMode;

--- a/nx/include/switch/kernel/svc.h
+++ b/nx/include/switch/kernel/svc.h
@@ -109,7 +109,7 @@ typedef struct {
 /// Secure monitor arguments.
 typedef struct {
     u64 X[8]; ///< Values of X0 through X7.
-} PACKED SecmonArgs;
+} NX_PACKED SecmonArgs;
 
 /// Break reasons
 typedef enum {
@@ -362,7 +362,7 @@ Result svcQueryMemory(MemoryInfo* meminfo_ptr, u32 *pageinfo, u64 addr);
  * @note Syscall number 0x07.
  */
 
-void NORETURN svcExitProcess(void);
+void NX_NORETURN svcExitProcess(void);
 
 /**
  * @brief Creates a thread.
@@ -382,7 +382,7 @@ Result svcStartThread(Handle handle);
  * @brief Exits the current thread.
  * @note Syscall number 0x0A.
  */
-void NORETURN svcExitThread(void);
+void NX_NORETURN svcExitThread(void);
 
 /**
  * @brief Sleeps the current thread for the specified amount of time.
@@ -668,7 +668,7 @@ Result svcOutputDebugString(const char *str, u64 size);
  * @param[in] res Result code.
  * @note Syscall number 0x28.
  */
-void NORETURN svcReturnFromException(Result res);
+void NX_NORETURN svcReturnFromException(Result res);
 
 /**
  * @brief Retrieves information about the system, or a certain kernel object.

--- a/nx/include/switch/kernel/thread.h
+++ b/nx/include/switch/kernel/thread.h
@@ -52,7 +52,7 @@ Result threadStart(Thread* t);
 /**
  * @brief Exits the current thread immediately.
  */
-void NORETURN threadExit(void);
+void NX_NORETURN threadExit(void);
 
 /**
  * @brief Waits for a thread to finish executing.

--- a/nx/include/switch/runtime/diag.h
+++ b/nx/include/switch/runtime/diag.h
@@ -12,4 +12,4 @@
  * @brief Aborts program execution with a result code.
  * @param[in] res Result code.
  */
-void NORETURN diagAbortWithResult(Result res);
+void NX_NORETURN diagAbortWithResult(Result res);

--- a/nx/include/switch/runtime/env.h
+++ b/nx/include/switch/runtime/env.h
@@ -45,7 +45,7 @@ enum {
 };
 
 /// Loader return function.
-typedef void NORETURN (*LoaderReturnFn)(int result_code);
+typedef void NX_NORETURN (*LoaderReturnFn)(int result_code);
 
 /**
  * @brief Parses the homebrew loader environment block (internally called).

--- a/nx/include/switch/services/fatal.h
+++ b/nx/include/switch/services/fatal.h
@@ -79,7 +79,7 @@ typedef struct {
  * @note This function does not return.
  * @note This uses \ref fatalThrowWithPolicy with \ref FatalPolicy_ErrorScreen internally.
  */
-void NORETURN fatalThrow(Result err);
+void NX_NORETURN fatalThrow(Result err);
 
 /**
  * @brief Triggers a system fatal error with a custom \ref FatalPolicy.

--- a/nx/include/switch/services/miiimg.h
+++ b/nx/include/switch/services/miiimg.h
@@ -20,7 +20,7 @@ typedef struct {
     MiiCreateId create_id;     ///< Mii's create ID.
     u32 unk;
     u16 mii_name[10+1];        ///< utf-16be, null-terminated
-} PACKED MiiimgImageAttribute;
+} NX_PACKED MiiimgImageAttribute;
 
 /// Initialize miiimg.
 Result miiimgInitialize(void);

--- a/nx/include/switch/services/nfc.h
+++ b/nx/include/switch/services/nfc.h
@@ -109,7 +109,7 @@ typedef struct {
     u32 protocol;
     u32 tag_type;
     u8  reserved2[0x30];
-} PACKED NfpTagInfo;
+} NX_PACKED NfpTagInfo;
 
 typedef struct {
     u8  uuid[10];
@@ -118,7 +118,7 @@ typedef struct {
     u32 protocol;
     u32 tag_type;
     u8  reserved2[0x30];
-} PACKED NfcTagInfo;
+} NX_PACKED NfcTagInfo;
 
 typedef struct {
     u16 last_write_year;
@@ -128,12 +128,12 @@ typedef struct {
     u16 version;
     u32 application_area_size;
     u8  reserved[0x34];
-} PACKED NfpCommonInfo;
+} NX_PACKED NfpCommonInfo;
 
 typedef struct {
     u8 amiibo_id[0x8];
     u8 reserved[0x38];
-} PACKED NfpModelInfo;
+} NX_PACKED NfpModelInfo;
 
 typedef struct {
     MiiCharInfo mii;
@@ -143,7 +143,7 @@ typedef struct {
     char amiibo_name[(10*4)+1]; ///< utf-8, null-terminated
     u8 font_region;
     u8 reserved[0x7A];
-} PACKED NfpRegisterInfo;
+} NX_PACKED NfpRegisterInfo;
 
 typedef struct {
     u8 mii_store_data[0x44];
@@ -153,7 +153,7 @@ typedef struct {
     char amiibo_name[(10*4)+1]; ///< utf-8, null-terminated
     u8 font_region;
     u8 reserved[0x8E];
-} PACKED NfpRegisterInfoPrivate;
+} NX_PACKED NfpRegisterInfoPrivate;
 
 typedef struct {
     u64 application_id;
@@ -163,7 +163,7 @@ typedef struct {
     u8 tag_type;
     u8 application_area_version;
     u8 reserved[0x2F];
-} PACKED NfpAdminInfo;
+} NX_PACKED NfpAdminInfo;
 
 typedef struct {
     u8 magic;
@@ -199,7 +199,7 @@ typedef struct {
     u8 application_id_byte; ///< (Original Program ID >> 0x24) & 0xF byte (Program ID has this byte swapped with console type)
     u8 reserved6[0x2E];
     u8 application_area[0xD8];
-} PACKED NfpData;
+} NX_PACKED NfpData;
 
 typedef struct {
     u8 mifare_command;
@@ -207,19 +207,19 @@ typedef struct {
     u8 reserved1[0x6];
     u8 sector_key[0x6];
     u8 reserved2[0x2];
-} PACKED NfcSectorKey;
+} NX_PACKED NfcSectorKey;
 
 typedef struct {
     u8 sector_number;
     u8 reserved[0x7];
     NfcSectorKey sector_key;
-} PACKED NfcMifareReadBlockParameter;
+} NX_PACKED NfcMifareReadBlockParameter;
 
 typedef struct {
     u8 data[0x10];
     u8 sector_number;
     u8 reserved[0x7];
-} PACKED NfcMifareReadBlockData;
+} NX_PACKED NfcMifareReadBlockData;
 
 typedef struct {
     u8 data[0x10];

--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -468,7 +468,7 @@ typedef struct {
             u8 svd_index : 7;
             u8 native_flag : 1;
         } svd[0xC];
-    } PACKED video;
+    } NX_PACKED video;
     struct {
         u8 size : 5;
         SetSysBlockType block_type : 3;
@@ -477,7 +477,7 @@ typedef struct {
         u8 padding1 : 1;
         u8 sampling_rates_bitmap;
         u8 bitrate;
-    } PACKED audio;
+    } NX_PACKED audio;
     struct {
         u8 size : 5;
         SetSysBlockType block_type : 3;
@@ -486,7 +486,7 @@ typedef struct {
         u8 mode_bitmap;
         u8 max_tmds_frequency;
         u8 latency_bitmap;
-    } PACKED vendor_specific;
+    } NX_PACKED vendor_specific;
     u8 padding[2];
 } SetSysDataBlock;
 

--- a/nx/include/switch/services/usb.h
+++ b/nx/include/switch/services/usb.h
@@ -29,7 +29,7 @@ struct usb_endpoint_descriptor {
     uint8_t  bmAttributes;
     uint16_t wMaxPacketSize;
     uint8_t  bInterval;
-} PACKED;
+} NX_PACKED;
 
 /// Imported from libusb, with some adjustments.
 struct usb_interface_descriptor {
@@ -72,7 +72,7 @@ struct usb_config_descriptor {
     uint8_t  iConfiguration;
     uint8_t  bmAttributes;
     uint8_t  MaxPower;
-} PACKED;
+} NX_PACKED;
 
 /// Imported from libusb, with some adjustments.
 struct usb_ss_endpoint_companion_descriptor {

--- a/nx/include/switch/services/usbhs.h
+++ b/nx/include/switch/services/usbhs.h
@@ -60,7 +60,7 @@ typedef struct {
     u8 pad_x155[0x6];
     struct usb_ss_endpoint_companion_descriptor output_ss_endpoint_companion_descs[15]; ///< ?
     u8 pad_x1b5[0x3];
-} PACKED UsbHsInterfaceInfo;
+} NX_PACKED UsbHsInterfaceInfo;
 
 /// Interface struct. Note that devices have a seperate \ref UsbHsInterface for each interface.
 typedef struct {
@@ -75,7 +75,7 @@ typedef struct {
     u8 pad_x21b[0x5];
 
     u64 timestamp; ///< Unknown u64 timestamp for when the device was inserted?
-} PACKED UsbHsInterface;
+} NX_PACKED UsbHsInterface;
 
 typedef struct {
     u32 xferId;

--- a/nx/include/switch/types.h
+++ b/nx/include/switch/types.h
@@ -59,26 +59,26 @@ typedef struct { float value[3]; } UtilFloat3;   ///< 3 floats.
 #endif
 
 /// Packs a struct so that it won't include padding bytes.
-#ifndef PACKED
-#define PACKED     __attribute__((packed))
+#ifndef NX_PACKED
+#define NX_PACKED     __attribute__((packed))
 #endif
 
 /// Marks a function as not returning, for the purposes of compiler optimization.
-#ifndef NORETURN
-#define NORETURN   __attribute__((noreturn))
+#ifndef NX_NORETURN
+#define NX_NORETURN   __attribute__((noreturn))
 #endif
 
 /// Performs a dummy operation on the specified argument in order to silence compiler warnings about unused arguments.
-#ifndef IGNORE_ARG
-#define IGNORE_ARG(x) (void)(x)
+#ifndef NX_IGNORE_ARG
+#define NX_IGNORE_ARG(x) (void)(x)
 #endif
 
 /// Flags a function as deprecated.
-#ifndef DEPRECATED
+#ifndef NX_DEPRECATED
 #ifndef LIBNX_NO_DEPRECATION
-#define DEPRECATED __attribute__ ((deprecated))
+#define NX_DEPRECATED __attribute__ ((deprecated))
 #else
-#define DEPRECATED
+#define NX_DEPRECATED
 #endif
 #endif
 

--- a/nx/source/runtime/env.c
+++ b/nx/source/runtime/env.c
@@ -7,7 +7,7 @@
 #include "services/acc.h"
 #include "runtime/diag.h"
 
-void NORETURN __nx_exit(Result rc, LoaderReturnFn retaddr);
+void NX_NORETURN __nx_exit(Result rc, LoaderReturnFn retaddr);
 
 static bool   g_isNso = false;
 static const char* g_loaderInfo = NULL;

--- a/nx/source/runtime/init.c
+++ b/nx/source/runtime/init.c
@@ -10,7 +10,7 @@
 #include "runtime/diag.h"
 #include "runtime/devices/fs_dev.h"
 
-void NORETURN __nx_exit(Result rc, LoaderReturnFn retaddr);
+void NX_NORETURN __nx_exit(Result rc, LoaderReturnFn retaddr);
 
 void virtmemSetup(void);
 void newlibSetup(void);
@@ -187,7 +187,7 @@ void __attribute__((weak)) __libnx_init(void* ctx, Handle main_thread, void* sav
     __libc_init_array();
 }
 
-void __attribute__((weak)) NORETURN __libnx_exit(int rc)
+void __attribute__((weak)) NX_NORETURN __libnx_exit(int rc)
 {
     // Call destructors.
     void __libc_fini_array(void);

--- a/nx/source/runtime/newlib.c
+++ b/nx/source/runtime/newlib.c
@@ -28,7 +28,7 @@ struct __pthread_t
     void *rc;
 };
 
-void __attribute__((weak)) NORETURN __libnx_exit(int rc);
+void __attribute__((weak)) NX_NORETURN __libnx_exit(int rc);
 
 /// TimeType passed to timeGetCurrentTime() during time initialization. If that fails and __nx_time_type isn't TimeType_Default, timeGetCurrentTime() will be called again with TimeType_Default.
 __attribute__((weak)) TimeType __nx_time_type = TimeType_Default;

--- a/nx/source/runtime/ringcon.c
+++ b/nx/source/runtime/ringcon.c
@@ -240,12 +240,12 @@ Result ringconReadId(RingCon *c, u64 *id_l, u64 *id_h) {
             struct {
               u32 data_x0;
               u16 data_x4;
-            } PACKED id_l;
+            } NX_PACKED id_l;
 
             struct {
               u32 data_x0;
               u16 data_x4;
-            } PACKED id_h;
+            } NX_PACKED id_h;
         } id;
     } reply;
 

--- a/nx/source/services/applet.c
+++ b/nx/source/services/applet.c
@@ -357,7 +357,7 @@ static void _appletInfiniteSleepLoop(void) {
     while(1) svcSleepThread(86400000000000ULL);
 }
 
-static void NORETURN _appletExitProcess(int result_code) {
+static void NX_NORETURN _appletExitProcess(int result_code) {
     appletInitialize();
     appletExit();
 

--- a/nx/source/services/fatal.c
+++ b/nx/source/services/fatal.c
@@ -53,7 +53,7 @@ static void _fatalCmd(Result err, FatalPolicy type, FatalCpuContext *ctx, u32 cm
     }
 }
 
-void NORETURN fatalThrow(Result err) {
+void NX_NORETURN fatalThrow(Result err) {
     // By default, do not generate an error report.
     fatalThrowWithPolicy(err, FatalPolicy_ErrorScreen);
     svcExitProcess();


### PR DESCRIPTION
Hello.

The ``PACKED`` macro conflicts with fmtlib 10. I prefixed your macros with ``NX_``.

This is the same issue fixed in libctru recently: 

- https://github.com/devkitPro/libctru/issues/530
- https://github.com/devkitPro/libctru/pull/532

Not sure if renaming ``NORETURN`` is a bad idea (compat issues?). I can undo this when you dislike it.

``IGNORE_ARG`` and ``DEPRECATED`` look unused in libnx.
