### PR TITLE
nv: Allow access to nvdrv:t

### DIFF
--- a/nx/source/services/nv.c
+++ b/nx/source/services/nv.c
@@ -32,9 +32,12 @@ Result _nvInitialize(void) {
         rc = smGetService(&g_nvSrv, "nvdrv:s");
         break;
 
+    case AppletType_SystemApplication:
+        rc = smGetService(&g_nvSrv, "nvdrv:t");
+        break;
+
     case AppletType_Default:
     case AppletType_Application:
-    case AppletType_SystemApplication:
     default:
         rc = smGetService(&g_nvSrv, "nvdrv");
         break;


### PR DESCRIPTION
Applications wishing to access NVJPG need to initialize `nvdrv:a`, as `nvdrv` does not have permission for this channel. However, it appears that this service only allows a limited amount of memory to be mapped using `/dev/nvhost-as-gpu` (around 430MiB in my testing).
As a workaround, this PR restores the possibility to access `nvdrv:t`, which was removed in efacee69564850e5772308938e58129a9244d44c. 

NB: it would be nicer to explicitely choose which type of service to initialize, like what is done in vi, but I didn't want to break backwards compatibility.