### PR TITLE
add fsDeviceOperatorGetGameCardUpdatePartitionInfo

### DIFF
--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -266,6 +266,12 @@ typedef struct {
 } FsGameCardHandle;
 
 typedef struct {
+    u32 version;
+    u8 pad[0x4];
+    u64 tid;
+} FsCardUpdatePartitionInfo;
+
+typedef struct {
     u32 aes_ctr_key_type;           ///< Contains bitflags describing how data is AES encrypted.
     u32 speed_emulation_type;       ///< Contains bitflags describing how data is emulated.
     u32 reserved[0x38/sizeof(u32)];
@@ -642,6 +648,7 @@ Result fsDeviceOperatorGetAndClearMmcErrorInfo(FsDeviceOperator* d, FsStorageErr
 Result fsDeviceOperatorGetMmcExtendedCsd(FsDeviceOperator* d, void* dst, size_t dst_size, s64 size);
 Result fsDeviceOperatorIsGameCardInserted(FsDeviceOperator* d, bool* out);
 Result fsDeviceOperatorGetGameCardHandle(FsDeviceOperator* d, FsGameCardHandle* out);
+Result fsDeviceOperatorGetGameCardUpdatePartitionInfo(FsDeviceOperator* d, const FsGameCardHandle* handle, FsCardUpdatePartitionInfo* out);
 Result fsDeviceOperatorGetGameCardAttribute(FsDeviceOperator* d, const FsGameCardHandle* handle, u8 *out);
 Result fsDeviceOperatorGetGameCardIdSet(FsDeviceOperator* d, void* dst, size_t dst_size, s64 size);
 Result fsDeviceOperatorGetGameCardErrorReportInfo(FsDeviceOperator* d, FsGameCardErrorReportInfo* out);

--- a/nx/include/switch/services/fs.h
+++ b/nx/include/switch/services/fs.h
@@ -268,8 +268,8 @@ typedef struct {
 typedef struct {
     u32 version;
     u8 pad[0x4];
-    u64 tid;
-} FsCardUpdatePartitionInfo;
+    u64 id;
+} FsGameCardUpdatePartitionInfo;
 
 typedef struct {
     u32 aes_ctr_key_type;           ///< Contains bitflags describing how data is AES encrypted.
@@ -648,7 +648,7 @@ Result fsDeviceOperatorGetAndClearMmcErrorInfo(FsDeviceOperator* d, FsStorageErr
 Result fsDeviceOperatorGetMmcExtendedCsd(FsDeviceOperator* d, void* dst, size_t dst_size, s64 size);
 Result fsDeviceOperatorIsGameCardInserted(FsDeviceOperator* d, bool* out);
 Result fsDeviceOperatorGetGameCardHandle(FsDeviceOperator* d, FsGameCardHandle* out);
-Result fsDeviceOperatorGetGameCardUpdatePartitionInfo(FsDeviceOperator* d, const FsGameCardHandle* handle, FsCardUpdatePartitionInfo* out);
+Result fsDeviceOperatorGetGameCardUpdatePartitionInfo(FsDeviceOperator* d, const FsGameCardHandle* handle, FsGameCardUpdatePartitionInfo* out);
 Result fsDeviceOperatorGetGameCardAttribute(FsDeviceOperator* d, const FsGameCardHandle* handle, u8 *out);
 Result fsDeviceOperatorGetGameCardIdSet(FsDeviceOperator* d, void* dst, size_t dst_size, s64 size);
 Result fsDeviceOperatorGetGameCardErrorReportInfo(FsDeviceOperator* d, FsGameCardErrorReportInfo* out);

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -1218,6 +1218,10 @@ Result fsDeviceOperatorGetGameCardHandle(FsDeviceOperator* d, FsGameCardHandle* 
     return _fsObjectDispatchOut(&d->s, 202, *out);
 }
 
+Result fsDeviceOperatorGetGameCardUpdatePartitionInfo(FsDeviceOperator* d, const FsGameCardHandle* handle, FsCardUpdatePartitionInfo* out) {
+    return _fsObjectDispatchInOut(&d->s, 203, *handle, *out);
+}
+
 Result fsDeviceOperatorGetGameCardAttribute(FsDeviceOperator* d, const FsGameCardHandle* handle, u8 *out) {
     return _fsObjectDispatchInOut(&d->s, 205, *handle, *out);
 }

--- a/nx/source/services/fs.c
+++ b/nx/source/services/fs.c
@@ -1218,7 +1218,7 @@ Result fsDeviceOperatorGetGameCardHandle(FsDeviceOperator* d, FsGameCardHandle* 
     return _fsObjectDispatchOut(&d->s, 202, *out);
 }
 
-Result fsDeviceOperatorGetGameCardUpdatePartitionInfo(FsDeviceOperator* d, const FsGameCardHandle* handle, FsCardUpdatePartitionInfo* out) {
+Result fsDeviceOperatorGetGameCardUpdatePartitionInfo(FsDeviceOperator* d, const FsGameCardHandle* handle, FsGameCardUpdatePartitionInfo* out) {
     return _fsObjectDispatchInOut(&d->s, 203, *handle, *out);
 }
 


### PR DESCRIPTION
i wasn't sure if the `version` field should be a bitfield or just a u32. if we keep it a u32, should i comment how to extract the version as it might not be obvious to the dev, as they may try to use `HOSVER_X` macros on it

```c
const u8 relstep = (update_partition_info.version >> 0)  & 0xFFFF;
const u8 micro   = (update_partition_info.version >> 16) & 0x000F;
const u8 minor   = (update_partition_info.version >> 20) & 0x003F;
const u8 major   = (update_partition_info.version >> 26) & 0x003F;
```