### PR TITLE
add audout:a audout:d aud:a aud:d

### DIFF
--- a/nx/include/switch/services/aud.h
+++ b/nx/include/switch/services/aud.h
@@ -1,0 +1,47 @@
+/**
+ * @file aud.h
+ * @brief Only available on [11.0.0+].
+ * @note Only one session may be open at once.
+ * @author TotalJustice
+ * @copyright libnx Authors
+ */
+
+#pragma once
+
+#include "../types.h"
+#include "../sf/service.h"
+
+#define AUD_MAX_DELAY (1000000000ULL)
+
+/// Initialize aud:a. Only available on [11.0.0+].
+Result audaInitialize(void);
+
+/// Exit aud:a.
+void audaExit(void);
+
+/// Initialize aud:d. Only available on [11.0.0+].
+Result auddInitialize(void);
+
+/// Exit aud:d.
+void auddExit(void);
+
+/// Gets the Service for aud:a.
+Service* audaGetServiceSession(void);
+
+/// Gets the Service for aud:d.
+Service* auddGetServiceSession(void);
+
+Result audaRequestSuspendAudio(u64 pid, u64 delay);
+Result audaRequestResumeAudio(u64 pid, u64 delay);
+Result audaGetAudioOutputProcessMasterVolume(u64 pid, float* volume_out);
+
+Result audaSetAudioOutputProcessMasterVolume(u64 pid, u64 delay, float volume);
+Result audaGetAudioInputProcessMasterVolume(u64 pid, float* volume_out);
+
+// Sets both Output and Input volume
+Result audaSetAudioInputProcessMasterVolume(u64 pid, u64 delay, float volume);
+Result audaGetAudioOutputProcessRecordVolume(u64 pid, float* volume_out);
+Result audaSetAudioOutputProcessRecordVolume(u64 pid, u64 delay, float volume);
+
+Result auddRequestSuspendAudioForDebug(u64 pid, u64 delay);
+Result auddRequestResumeAudioForDebug(u64 pid, u64 delay);

--- a/nx/include/switch/services/audout.h
+++ b/nx/include/switch/services/audout.h
@@ -108,8 +108,8 @@ Result audoutaRequestSuspend(u64 pid, u64 delay); // [4.0.0+]
 Result audoutaRequestResume(u64 pid, u64 delay); // [4.0.0+]
 Result audoutaGetProcessMasterVolume(u64 pid, float* volume_out);
 Result audoutaSetProcessMasterVolume(u64 pid, u64 delay, float volume);
-Result audoutaGetProcessRecordVolume(u64 pid, float* volume_out);
-Result audoutaSetProcessRecordVolume(u64 pid, u64 delay, float volume);
+Result audoutaGetProcessRecordVolume(u64 pid, float* volume_out); // [4.0.0+]
+Result audoutaSetProcessRecordVolume(u64 pid, u64 delay, float volume); // [4.0.0+]
 
 Result audoutdRequestSuspendForDebug(u64 pid, u64 delay);
 Result audoutdRequestResumeForDebug(u64 pid, u64 delay);

--- a/nx/include/switch/services/audout.h
+++ b/nx/include/switch/services/audout.h
@@ -1,7 +1,7 @@
 /**
  * @file audout.h
  * @brief Audio output service.
- * @author hexkyz
+ * @author hexkyz, TotalJustice
  * @copyright libnx Authors
  */
 #pragma once
@@ -104,8 +104,6 @@ u32 audoutGetChannelCount(void);                    ///< Supported channel count
 PcmFormat audoutGetPcmFormat(void);                 ///< Supported PCM format (Int16).
 AudioOutState audoutGetDeviceState(void);           ///< Initial device state (stopped).
 
-Result audoutaRequestSuspendOld(u64 pid, u64 delay, Handle* handle_out); // [1.0.0] - [4.0.0]
-Result audoutaRequestResumeOld(u64 pid, u64 delay, Handle* handle_out); // [1.0.0] - [4.0.0]
 Result audoutaRequestSuspend(u64 pid, u64 delay); // [4.0.0]+
 Result audoutaRequestResume(u64 pid, u64 delay); // [4.0.0]+
 Result audoutaGetProcessMasterVolume(u64 pid, float* volume_out);

--- a/nx/include/switch/services/audout.h
+++ b/nx/include/switch/services/audout.h
@@ -104,8 +104,8 @@ u32 audoutGetChannelCount(void);                    ///< Supported channel count
 PcmFormat audoutGetPcmFormat(void);                 ///< Supported PCM format (Int16).
 AudioOutState audoutGetDeviceState(void);           ///< Initial device state (stopped).
 
-Result audoutaRequestSuspend(u64 pid, u64 delay); // [4.0.0]+
-Result audoutaRequestResume(u64 pid, u64 delay); // [4.0.0]+
+Result audoutaRequestSuspend(u64 pid, u64 delay); // [4.0.0+]
+Result audoutaRequestResume(u64 pid, u64 delay); // [4.0.0+]
 Result audoutaGetProcessMasterVolume(u64 pid, float* volume_out);
 Result audoutaSetProcessMasterVolume(u64 pid, u64 delay, float volume);
 Result audoutaGetProcessRecordVolume(u64 pid, float* volume_out);

--- a/nx/include/switch/services/audout.h
+++ b/nx/include/switch/services/audout.h
@@ -10,6 +10,8 @@
 #include "../audio/audio.h"
 #include "../sf/service.h"
 
+#define AUDOUT_MAX_DELAY (1000000000ULL)
+
 typedef enum {
     AudioOutState_Started = 0,
     AudioOutState_Stopped = 1,
@@ -33,11 +35,29 @@ Result audoutInitialize(void);
 /// Exit audout.
 void audoutExit(void);
 
+/// Initialize audout:a. Removed in [11.0.0].
+Result audoutaInitialize(void);
+
+/// Exit audout:a.
+void audoutaExit(void);
+
+/// Initialize audout:d. Removed in [11.0.0].
+Result audoutdInitialize(void);
+
+/// Exit audout:d.
+void audoutdExit(void);
+
 /// Gets the Service object for the actual audout service session.
 Service* audoutGetServiceSession(void);
 
 /// Gets the Service object for IAudioOut.
 Service* audoutGetServiceSession_AudioOut(void);
+
+/// Gets the Service for audout:a.
+Service* audoutaGetServiceSession(void);
+
+/// Gets the Service for audout:d.
+Service* audoutdGetServiceSession(void);
 
 Result audoutListAudioOuts(char *DeviceNames, s32 count, u32 *DeviceNamesCount);
 Result audoutOpenAudioOut(const char *DeviceNameIn, char *DeviceNameOut, u32 SampleRateIn, u32 ChannelCountIn, u32 *SampleRateOut, u32 *ChannelCountOut, PcmFormat *Format, AudioOutState *State);
@@ -83,3 +103,15 @@ u32 audoutGetSampleRate(void);                      ///< Supported sample rate (
 u32 audoutGetChannelCount(void);                    ///< Supported channel count (2 channels).
 PcmFormat audoutGetPcmFormat(void);                 ///< Supported PCM format (Int16).
 AudioOutState audoutGetDeviceState(void);           ///< Initial device state (stopped).
+
+Result audoutaRequestSuspendOld(u64 pid, u64 delay, Handle* handle_out); // [1.0.0] - [4.0.0]
+Result audoutaRequestResumeOld(u64 pid, u64 delay, Handle* handle_out); // [1.0.0] - [4.0.0]
+Result audoutaRequestSuspend(u64 pid, u64 delay); // [4.0.0]+
+Result audoutaRequestResume(u64 pid, u64 delay); // [4.0.0]+
+Result audoutaGetProcessMasterVolume(u64 pid, float* volume_out);
+Result audoutaSetProcessMasterVolume(u64 pid, u64 delay, float volume);
+Result audoutaGetProcessRecordVolume(u64 pid, float* volume_out);
+Result audoutaSetProcessRecordVolume(u64 pid, u64 delay, float volume);
+
+Result audoutdRequestSuspendForDebug(u64 pid, u64 delay);
+Result audoutdRequestResumeForDebug(u64 pid, u64 delay);

--- a/nx/source/services/aud.c
+++ b/nx/source/services/aud.c
@@ -1,0 +1,115 @@
+#define NX_SERVICE_ASSUME_NON_DOMAIN
+#include "service_guard.h"
+#include "services/aud.h"
+#include "runtime/hosversion.h"
+
+static Service g_audaSrv;
+static Service g_auddSrv;
+
+NX_GENERATE_SERVICE_GUARD(auda);
+NX_GENERATE_SERVICE_GUARD(audd);
+
+Result _audaInitialize(void) {
+    if (hosversionBefore(11,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
+    return smGetService(&g_audaSrv, "aud:a");
+}
+
+void _audaCleanup(void) {
+    serviceClose(&g_audaSrv);
+}
+
+Result _auddInitialize(void) {
+    return smGetService(&g_auddSrv, "aud:d");
+}
+
+void _auddCleanup(void) {
+    serviceClose(&g_auddSrv);
+}
+
+Service* audaGetServiceSession(void) {
+    return &g_audaSrv;
+}
+
+Service* auddGetServiceSession(void) {
+    return &g_auddSrv;
+}
+
+Result audaRequestSuspendAudio(u64 pid, u64 delay) {
+    const struct {
+        u64 pid;
+        u64 timespan;
+    } in = { pid, delay };
+
+    return serviceDispatchIn(&g_audaSrv, 2, in);
+}
+
+Result audaRequestResumeAudio(u64 pid, u64 delay) {
+    const struct {
+        u64 pid;
+        u64 timespan;
+    } in = { pid, delay };
+
+    return serviceDispatchIn(&g_audaSrv, 3, in);
+}
+
+Result audaGetAudioOutputProcessMasterVolume(u64 pid, float* volume_out) {
+    return serviceDispatchInOut(&g_audaSrv, 4, pid, *volume_out);
+}
+
+Result audaSetAudioOutputProcessMasterVolume(u64 pid, u64 delay, float volume) {
+    const struct {
+        float volume;
+        u64 pid;
+        u64 timespan;
+    } in = { volume, pid, delay };
+
+    return serviceDispatchIn(&g_audaSrv, 5, in);
+}
+
+Result audaGetAudioInputProcessMasterVolume(u64 pid, float* volume_out) {
+    return serviceDispatchInOut(&g_audaSrv, 6, pid, *volume_out);
+}
+
+Result audaSetAudioInputProcessMasterVolume(u64 pid, u64 delay, float volume) {
+    const struct {
+        float volume;
+        u64 pid;
+        u64 timespan;
+    } in = { volume, pid, delay };
+
+    return serviceDispatchIn(&g_audaSrv, 7, in);
+}
+
+Result audaGetAudioOutputProcessRecordVolume(u64 pid, float* volume_out) {
+    return serviceDispatchInOut(&g_audaSrv, 8, pid, *volume_out);
+}
+
+Result audaSetAudioOutputProcessRecordVolume(u64 pid, u64 delay, float volume) {
+    const struct {
+        float volume;
+        u64 pid;
+        u64 timespan;
+    } in = { volume, pid, delay };
+
+    return serviceDispatchIn(&g_audaSrv, 9, in);
+}
+
+Result auddRequestSuspendAudioForDebug(u64 pid, u64 delay) {
+    const struct {
+        u64 pid;
+        u64 timespan;
+    } in = { pid, delay };
+
+    return serviceDispatchIn(&g_auddSrv, 0, in);
+}
+
+Result auddRequestResumeAudioForDebug(u64 pid, u64 delay) {
+    const struct {
+        u64 pid;
+        u64 timespan;
+    } in = { pid, delay };
+
+    return serviceDispatchIn(&g_auddSrv, 1, in);
+}

--- a/nx/source/services/aud.c
+++ b/nx/source/services/aud.c
@@ -21,6 +21,9 @@ void _audaCleanup(void) {
 }
 
 Result _auddInitialize(void) {
+    if (hosversionBefore(11,0,0))
+        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
+
     return smGetService(&g_auddSrv, "aud:d");
 }
 

--- a/nx/source/services/aud.c
+++ b/nx/source/services/aud.c
@@ -39,7 +39,7 @@ Service* auddGetServiceSession(void) {
 Result audaRequestSuspendAudio(u64 pid, u64 delay) {
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchIn(&g_audaSrv, 2, in);
@@ -48,7 +48,7 @@ Result audaRequestSuspendAudio(u64 pid, u64 delay) {
 Result audaRequestResumeAudio(u64 pid, u64 delay) {
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchIn(&g_audaSrv, 3, in);
@@ -62,7 +62,7 @@ Result audaSetAudioOutputProcessMasterVolume(u64 pid, u64 delay, float volume) {
     const struct {
         float volume;
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { volume, pid, delay };
 
     return serviceDispatchIn(&g_audaSrv, 5, in);
@@ -76,7 +76,7 @@ Result audaSetAudioInputProcessMasterVolume(u64 pid, u64 delay, float volume) {
     const struct {
         float volume;
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { volume, pid, delay };
 
     return serviceDispatchIn(&g_audaSrv, 7, in);
@@ -90,7 +90,7 @@ Result audaSetAudioOutputProcessRecordVolume(u64 pid, u64 delay, float volume) {
     const struct {
         float volume;
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { volume, pid, delay };
 
     return serviceDispatchIn(&g_audaSrv, 9, in);
@@ -99,7 +99,7 @@ Result audaSetAudioOutputProcessRecordVolume(u64 pid, u64 delay, float volume) {
 Result auddRequestSuspendAudioForDebug(u64 pid, u64 delay) {
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchIn(&g_auddSrv, 0, in);
@@ -108,7 +108,7 @@ Result auddRequestSuspendAudioForDebug(u64 pid, u64 delay) {
 Result auddRequestResumeAudioForDebug(u64 pid, u64 delay) {
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchIn(&g_auddSrv, 1, in);

--- a/nx/source/services/audout.c
+++ b/nx/source/services/audout.c
@@ -294,30 +294,6 @@ Result audoutGetAudioOutVolume(float *volume) {
     return serviceDispatchOut(&g_audoutIAudioOut, 13, *volume);
 }
 
-Result audoutaRequestSuspendOld(u64 pid, u64 delay, Handle* handle_out) {
-    if (hosversionAtLeast(4,0,0))
-        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
-
-    const struct {
-        u64 pid;
-        u64 delay;
-    } in = { pid, delay };
-
-    return serviceDispatchInOut(&g_audoutaSrv, 0, in, *handle_out);
-}
-
-Result audoutaRequestResumeOld(u64 pid, u64 delay, Handle* handle_out) {
-    if (hosversionAtLeast(4,0,0))
-        return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);
-
-    const struct {
-        u64 pid;
-        u64 delay;
-    } in = { pid, delay };
-
-    return serviceDispatchInOut(&g_audoutaSrv, 1, in, *handle_out);
-}
-
 Result audoutaRequestSuspend(u64 pid, u64 delay) {
     if (hosversionBefore(4,0,0))
         return MAKERESULT(Module_Libnx, LibnxError_IncompatSysVer);

--- a/nx/source/services/audout.c
+++ b/nx/source/services/audout.c
@@ -300,7 +300,7 @@ Result audoutaRequestSuspendOld(u64 pid, u64 delay, Handle* handle_out) {
 
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchInOut(&g_audoutaSrv, 0, in, *handle_out);
@@ -312,7 +312,7 @@ Result audoutaRequestResumeOld(u64 pid, u64 delay, Handle* handle_out) {
 
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchInOut(&g_audoutaSrv, 1, in, *handle_out);
@@ -324,7 +324,7 @@ Result audoutaRequestSuspend(u64 pid, u64 delay) {
 
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchIn(&g_audoutaSrv, 0, in);
@@ -336,7 +336,7 @@ Result audoutaRequestResume(u64 pid, u64 delay) {
 
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchIn(&g_audoutaSrv, 1, in);
@@ -350,8 +350,8 @@ Result audoutaSetProcessMasterVolume(u64 pid, u64 delay, float volume) {
     const struct {
         float volume;
         u64 pid;
-        u64 timespan;
-    } in = { volume, pid, 0 };
+        u64 delay;
+    } in = { volume, pid, delay };
 
     return serviceDispatchIn(&g_audoutaSrv, 3, in);
 }
@@ -370,7 +370,7 @@ Result audoutaSetProcessRecordVolume(u64 pid, u64 delay, float volume) {
     const struct {
         float volume;
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { volume, pid, delay };
 
     return serviceDispatchIn(&g_audoutaSrv, 5, in);
@@ -379,7 +379,7 @@ Result audoutaSetProcessRecordVolume(u64 pid, u64 delay, float volume) {
 Result audoutdRequestSuspendForDebug(u64 pid, u64 delay) {
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchIn(&g_audoutdSrv, 0, in);
@@ -388,7 +388,7 @@ Result audoutdRequestSuspendForDebug(u64 pid, u64 delay) {
 Result audoutdRequestResumeForDebug(u64 pid, u64 delay) {
     const struct {
         u64 pid;
-        u64 timespan;
+        u64 delay;
     } in = { pid, delay };
 
     return serviceDispatchIn(&g_audoutdSrv, 1, in);


### PR DESCRIPTION
Application use: I use this in [sys-tune](https://github.com/HookedBehemoth/sys-tune/tree/master/sys-tune/source/impl) to allow for per title volume control whilst keeping the master volume the same.

I've tried to match the style of audout.c/h. It is lacking comments, but i think the function names are descriptive enough.

I have a wrapper for common functions as well, but that probably doesn't belong in libnx :)
