### PR TITLE
nvchannel: Fix SET_CLK_RATE, implement GET_CLK_RATE and SET_SUBMIT_TIMEOUT

### DIFF
--- a/nx/include/switch/nvidia/ioctl.h
+++ b/nx/include/switch/nvidia/ioctl.h
@@ -162,8 +162,8 @@ typedef struct {
 } nvioctl_command_buffer_map;
 
 typedef struct {
-    uint32_t rate;
-    uint32_t moduleid;
+    u32 rate;
+    u32 moduleid;
 } nvioctl_clk_rate;
 
 #define NVGPU_ZBC_TYPE_INVALID     0

--- a/nx/include/switch/nvidia/ioctl.h
+++ b/nx/include/switch/nvidia/ioctl.h
@@ -161,6 +161,11 @@ typedef struct {
     u32 iova;
 } nvioctl_command_buffer_map;
 
+typedef struct {
+    uint32_t rate;
+    uint32_t moduleid;
+} nvioctl_clk_rate;
+
 #define NVGPU_ZBC_TYPE_INVALID     0
 #define NVGPU_ZBC_TYPE_COLOR       1
 #define NVGPU_ZBC_TYPE_DEPTH       2
@@ -284,5 +289,7 @@ Result nvioctlChannel_Submit(u32 fd, const nvioctl_cmdbuf *cmdbufs, u32 num_cmdb
     const nvioctl_syncpt_incr *syncpt_incrs, u32 num_syncpt_incrs, nvioctl_fence *fences, u32 num_fences);
 Result nvioctlChannel_GetSyncpt(u32 fd, u32 module_id, u32 *syncpt);
 Result nvioctlChannel_GetModuleClockRate(u32 fd, u32 module_id, u32 *freq);
+Result nvioctlChannel_SetModuleClockRate(u32 fd, u32 module_id, u32 freq);
 Result nvioctlChannel_MapCommandBuffer(u32 fd, nvioctl_command_buffer_map *maps, u32 num_maps, bool compressed);
 Result nvioctlChannel_UnmapCommandBuffer(u32 fd, const nvioctl_command_buffer_map *maps, u32 num_maps, bool compressed);
+Result nvioctlChannel_SetSubmitTimeout(u32 fd, u32 timeout);

--- a/nx/source/nvidia/ioctl/nvchannel.c
+++ b/nx/source/nvidia/ioctl/nvchannel.c
@@ -261,8 +261,8 @@ Result nvioctlChannel_GetModuleClockRate(u32 fd, u32 module_id, u32 *freq) {
         .module = module_id,
     };
 
-    u32 ioctl = _NV_IOWR(0, hosversionAtLeast(8,0,0) ? 0x14 : 0x23, data);
-    Result rc = nvIoctl(fd, ioctl, &data);
+    u32 nr = _NV_IOWR(0, hosversionBefore(8,0,0) ? 0x14 : 0x23, data);
+    Result rc = nvIoctl(fd, nr, &data);
 
     if (R_SUCCEEDED(rc) && freq)
         *freq = data.rate;

--- a/nx/source/nvidia/ioctl/nvchannel.c
+++ b/nx/source/nvidia/ioctl/nvchannel.c
@@ -254,11 +254,8 @@ Result nvioctlChannel_GetSyncpt(u32 fd, u32 id, u32 *syncpt) {
 }
 
 Result nvioctlChannel_GetModuleClockRate(u32 fd, u32 module_id, u32 *freq) {
-    struct {
-        __nv_out u32 rate;
-        __nv_in  u32 module;
-    } data = {
-        .module = module_id,
+    nvioctl_clk_rate data = {
+        .moduleid = module_id,
     };
 
     u32 nr = _NV_IOWR(0, hosversionBefore(8,0,0) ? 0x14 : 0x23, data);
@@ -268,6 +265,25 @@ Result nvioctlChannel_GetModuleClockRate(u32 fd, u32 module_id, u32 *freq) {
         *freq = data.rate;
 
     return rc;
+}
+
+Result nvioctlChannel_SetModuleClockRate(u32 fd, u32 module_id, u32 freq) {
+    nvioctl_clk_rate data = {
+        .rate     = freq,
+        .moduleid = module_id,
+    };
+
+    return nvIoctl(fd, _NV_IOW(0, 0x08, data), &data);
+}
+
+Result nvioctlChannel_SetSubmitTimeout(u32 fd, u32 timeout) {
+    struct {
+        __nv_in u32 timeout;
+    } data = {
+        .timeout = timeout,
+    };
+
+    return nvIoctl(fd, _NV_IOW(0, 0x07, data), &data);
 }
 
 Result nvioctlChannel_MapCommandBuffer(u32 fd, nvioctl_command_buffer_map *maps, u32 num_maps, bool compressed) {


### PR DESCRIPTION
The version check was accidentally inverted in SET_CLK_RATE.
These are used for video engines and VIC.