### PR TITLE
Fix: avoid segfault at static destructors

### DIFF
--- a/nx/source/runtime/init.c
+++ b/nx/source/runtime/init.c
@@ -189,10 +189,6 @@ void __attribute__((weak)) __libnx_init(void* ctx, Handle main_thread, void* sav
 
 void __attribute__((weak)) NX_NORETURN __libnx_exit(int rc)
 {
-    // Call destructors.
-    void __libc_fini_array(void);
-    __libc_fini_array();
-
     // Clean up services.
     __appExit();
 


### PR DESCRIPTION
The `exit` routine executed after `main` returned already calls `libc_fini_array`. Calling it again within `__libnx_exit` calls the destructor for static objects a second time which results in a segfault when static/global objects are used in a program.