### PR TITLE
Add native RomFS file and directory handling

### DIFF
--- a/nx/include/switch/runtime/devices/romfs_dev.h
+++ b/nx/include/switch/runtime/devices/romfs_dev.h
@@ -132,6 +132,8 @@ typedef struct
 
     u64 offset; ///< The starting offset in RomFS for file data.
     u64 pos;    ///< Current read position into the file.
+
+    int err;
 } romfs_fileobj;
 
 /**
@@ -174,7 +176,7 @@ typedef struct
 {
     romfs_mount *mount;    ///< The RomFS mount associated with the directory.
     romfs_dir   *dir;      ///< Information about the directory being searched.
-    u32         state;     ///< Current iteration count.
+    int         state;     ///< Current iteration count or error code
     u32         childDir;  ///< Next child directory of the directory.
     u32         childFile; ///< Next child file of the directory.
 } romfs_diriter;
@@ -190,8 +192,8 @@ typedef struct
     RomfsDirEntryType type; ///< Type of this entry.
     union
     {
-        const romfs_file *file;  ///< Entry information if type is RomfsDirEntryType_File.
-        const romfs_dir  *dir;   ///< Entry information if type is RomfsDirEntryType_Dir.
+        romfs_file *file;  ///< Entry information if type is RomfsDirEntryType_File.
+        romfs_dir  *dir;   ///< Entry information if type is RomfsDirEntryType_Dir.
     };
 
     const char *name; ///< Basename of the entry, not null-terminated, UTF-8 coded.

--- a/nx/include/switch/runtime/devices/romfs_dev.h
+++ b/nx/include/switch/runtime/devices/romfs_dev.h
@@ -120,3 +120,105 @@ static inline Result romfsExit(void)
 {
     return romfsUnmount("romfs");
 }
+
+/// Opaque handle to a RomFS mount
+typedef struct romfs_mount romfs_mount;
+
+/// Object for interacting with a romfs_file
+typedef struct
+{
+    romfs_mount *mount; ///< The RomFS mount the file is associated with.
+    romfs_file  *file;  ///< Detail about the actual RomFS file.
+
+    u64 offset; ///< The starting offset in RomFS for file data.
+    u64 pos;    ///< Current read position into the file.
+} romfs_fileobj;
+
+/**
+ * @brief Finds a RomFS mount by the given name, the default mount name is "romfs"
+ * @param name The name of the mount to search for
+ * @param mount A pointer to a romfs_mount pointer to fill out with the mount information
+ */
+Result romfsFindMount(const char *name, romfs_mount **mount);
+
+/**
+ * @brief Finds a file in RomFS automatically determining the mount
+ * @param path The path to the file
+ * @param file A pointer to a romfs_fileobj structure to fill out
+ * @remark The path structure should follow <mount name>:<path> (i.e. romfs:/data/file.txt)
+ *         If no mount name is provided the default of "romfs" will be used.
+ */
+Result romfsFindFile(const char *path, romfs_fileobj *file);
+
+/**
+ * @brief Finds a file in a specific RomFS mount
+ * @param mount The mount to search in
+ * @param path The path to the file
+ * @param file A pointer to a romfs_fileobj structure to fill out
+ * @remark The mount name prefix is not required and is ignored if provided
+ */
+Result romfsFindFileInMount(romfs_mount *mount, const char *path, romfs_fileobj *file);
+
+/**
+ * @brief Reads data from the specified RomFS file.
+ * @param file The RomFS file to read from.
+ * @param buffer The buffer to read data into.
+ * @param size The number of bytes to read.
+ * @param offset The offset in bytes from the beginning of the file to start reading from.
+ * @param nread A pointer in which the number of total bytes read will be written to.
+ * @remark The file's position pointer is not updated by this function.
+ */
+Result romfsReadFile(romfs_fileobj *file, void *buffer, u64 size, u64 offset, u64 *nread);
+
+typedef struct
+{
+    romfs_mount *mount;    ///< The RomFS mount associated with the directory.
+    romfs_dir   *dir;      ///< Information about the directory being searched.
+    u32         state;     ///< Current iteration count.
+    u32         childDir;  ///< Next child directory of the directory.
+    u32         childFile; ///< Next child file of the directory.
+} romfs_diriter;
+
+typedef enum
+{
+    RomfsDirEntryType_File = 0,
+    RomfsDirEntryType_Dir
+} RomfsDirEntryType;
+
+typedef struct
+{
+    RomfsDirEntryType type; ///< Type of this entry.
+    union
+    {
+        const romfs_file *file;  ///< Entry information if type is RomfsDirEntryType_File.
+        const romfs_dir  *dir;   ///< Entry information if type is RomfsDirEntryType_Dir.
+    };
+
+    const char *name; ///< Basename of the entry, not null-terminated, UTF-8 coded.
+    u32 name_len;     ///< Length in bytes of the basename.
+} romfs_direntry;
+
+/**
+ * @brief Initialises the directory iterator for seaching at the given path, automatically determines mount.
+ * @param path The directory path to search.
+ * @param iter The directory iterator to fill out with found information.
+ * @remark The path structure should follow <mount name>:<path> (i.e. romfs:/data/folder).
+ *         If no mount name is provided the default of "romfs" will be used.
+ */
+Result romfsDirOpen(const char *path, romfs_diriter *iter);
+
+/**
+ * @brief Initialises the directory iterator for seaching at the given path in the supplied mount.
+ * @param mount The RomFS mount to search in.
+ * @param path The directory path to search.
+ * @param iter The directory iterator to fill out with found information.
+ * @remark The mount does not need to be specified in the path and is ignored if provided.
+ */
+Result romfsDirOpenWithMount(romfs_mount *mount, const char *path, romfs_diriter *iter);
+
+/**
+ * @brief Gets the next entry in the directory, returns false on error or when no more entries are found.
+ * @param iter The directory iterator.
+ * @param entry The entry to fill out with information.
+ */
+bool romfsDirNext(romfs_diriter *iter, romfs_direntry *entry);


### PR DESCRIPTION
This exposes some more of the RomFS API to the public facing side allowing file "opening" and directory listing natively without requiring stdio. The main reason for this is to allow reading RomFS files from an arbitary offset without first seeking the file position. As RomFS is read-only this is crucial for contentionless multi-threaded access, but is unfortunately missing from stdio. I kinda just did the directory iteration stuff to round out the API, they both have the added benefit of requiring zero allocation.

The stdio implementation has been updated to use the native APIs as well with a slight caveat when calling `romfs_open`. It used to return `ENOENT` if the directory didn't exist but `EROFS` if the file didn't exist and the `O_CREAT` flag was set. It now returns `EROFS` in either case if the `O_CREAT` flag is set.

I'm happy to write up an example usage for the switchbrew/switch-examples repository.