### PR TITLE
nvfence: expose nvhost-ctrl fd

### DIFF
--- a/nx/include/switch/nvidia/fence.h
+++ b/nx/include/switch/nvidia/fence.h
@@ -10,6 +10,7 @@ typedef struct {
 
 Result nvFenceInit(void);
 void nvFenceExit(void);
+u32 nvFenceGetFd(void);
 
 Result nvFenceWait(NvFence* f, s32 timeout_us);
 

--- a/nx/source/nvidia/fence.c
+++ b/nx/source/nvidia/fence.c
@@ -82,6 +82,11 @@ void _nvFenceCleanup(void)
     }
 }
 
+u32 nvFenceGetFd(void)
+{
+    return g_ctrl_fd;
+}
+
 static Result _nvFenceEventWaitCommon(Event* event, u32 event_id, s32 timeout_us)
 {
     u64 timeout_ns = UINT64_MAX;


### PR DESCRIPTION
This is needed eg. to read syncpt values.