### PR TITLE
nvchannel: fix submit ioctl

### DIFF
--- a/nx/include/switch/nvidia/ioctl.h
+++ b/nx/include/switch/nvidia/ioctl.h
@@ -154,6 +154,9 @@ typedef struct {
 typedef struct {
     u32 syncpt_id;
     u32 syncpt_incrs;
+    u32 waitbase_id; // Always -1
+    u32 next; //< Next valid incr index, or -1
+    u32 prev; //< Previous valid incr index, or -1
 } nvioctl_syncpt_incr;
 
 typedef struct {


### PR DESCRIPTION
The former code worked by chance if users submitted a single syncpt increment. This matches the layout described on the switchbrew wiki, that was fixed some time ago.