### PR TITLE
Add nxlinkConnectToHost note about the socket driver

### DIFF
--- a/nx/include/switch/runtime/nxlink.h
+++ b/nx/include/switch/runtime/nxlink.h
@@ -21,6 +21,7 @@ extern struct in_addr __nxlink_host;
  * @param[in] redirStderr Whether to redirect stderr to nxlink output.
  * @return Socket fd on success, negative number on failure.
  * @note The socket should be closed with close() during application cleanup.
+ * The socket driver must be initialized, otherwise the call will fail.
  */
 int nxlinkConnectToHost(bool redirStdout, bool redirStderr);
 


### PR DESCRIPTION
Add a comment that the socket driver must be initialized prior to calling this function, otherwise this function will fail.

After debugging it for sometime I found [this post] (https://gbatemp.net/threads/my-sdl2-game-crash-at-launch-how-to-debug-it.611957/) which helped me and I hope this could save some time for others as well.