### PR TITLE
Update SetSysEdid to include different types of Extension blocks

### DIFF
--- a/nx/include/switch/services/set.h
+++ b/nx/include/switch/services/set.h
@@ -501,12 +501,12 @@ typedef struct {
         } NX_PACKED cea;                                     ///< CEA EDID timing extension
         struct {
             u8 data[0x7E];
-        } display_id;                              ///< [13.0.0+] DisplayID Extension Block
+        } display_id;                                        ///< [13.0.0+] DisplayID Extension Block
         struct {
             u8 second_block_extension_tag;
             u8 third_block_extension_tag;
             u8 padding[0x7C];
-        } block_map;                               ///< [13.0.0+] EDID Extension Block Map
+        } block_map;                                         ///< [13.0.0+] EDID Extension Block Map
     } extension_block;
     u8 extended_checksum;                                    ///< Sum of 128 extended bytes should equal 0 mod 256.
 } SetSysExtensionBlock;


### PR DESCRIPTION
Someone reported to me EDID retrieved by Switch OLED in OLED dock (in OG dock all extension blocks were removed) with additional extension blocks and it includes types 0xF0 and 0x70. That's why I have decided to update SetSysEdid based on new extension blocks.

Here is EDID dump
```
00 ff ff ff ff ff ff 00 1e 6d 33 5c 27 4f 05 00
06 21 01 03 80 3b 21 78 e8 39 8c ad 52 41 af 25
0e 4a 4d 21 09 00 d1 c0 81 c0 61 40 01 01 01 01
01 01 01 01 01 01 56 5e 00 a0 a0 a0 29 50 30 20
35 00 4e 4d 21 00 00 1a 00 00 00 fd 00 30 f0 1e
ff 6a 00 0a 20 20 20 20 20 20 00 00 00 fc 00 4c
47 20 55 4c 54 52 41 47 45 41 52 2b 00 00 00 ff
00 33 30 36 4e 54 56 53 41 37 39 34 33 0a 03 86

f0 02 70 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 9e

02 03 56 73 23 0f 57 07 83 01 00 00 50 61 60 5f
5e 5d 22 20 1f 12 10 04 03 01 13 3f 76 6d 03 0c
00 20 00 b8 44 20 00 60 01 02 03 6a d8 5d c4 01
78 80 63 00 30 f0 e3 0f 03 80 e2 00 6a e3 05 c0
00 e6 06 05 01 73 33 0a 6d 1a 00 00 02 01 30 f0
00 04 73 0a 33 15 ef e7 00 a0 a0 a0 4c 50 30 20
35 00 4e 4d 21 00 00 1a 6f c2 00 a0 a0 a0 55 50
30 20 35 00 4e 4d 21 00 00 1a 00 00 00 00 00 67

70 12 79 03 00 01 00 0c 10 17 09 0d 00 0a a0 05
90 78 4e bb 0f 00 0a 74 21 0e 0e 07 01 23 00 00
00 03 01 14 ca 9c 01 84 ff 09 9f 00 2f 80 1f 00
9f 05 b2 00 02 00 04 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
00 00 00 00 00 00 00 00 00 00 00 00 00 00 9f 90
```