### PR TITLE
Update Makefile to reflex 4.9.0 version

### DIFF
--- a/nx/Makefile
+++ b/nx/Makefile
@@ -9,7 +9,7 @@ endif
 include $(DEVKITPRO)/devkitA64/base_rules
 
 export LIBNX_MAJOR	:= 4
-export LIBNX_MINOR	:= 7
+export LIBNX_MINOR	:= 9
 export LIBNX_PATCH	:= 0
 
 


### PR DESCRIPTION
Correct small overlook update to the makefile, so `make install` creates the correct filename