### PR TITLE
vi: swap close layer commands

### DIFF
--- a/nx/source/services/vi.c
+++ b/nx/source/services/vi.c
@@ -451,7 +451,7 @@ Result viCloseLayer(ViLayer *layer) {
         return MAKERESULT(Module_Libnx, LibnxError_NotInitialized);
     }
 
-    Result rc = serviceDispatchIn(&g_viIApplicationDisplayService, layer->stray_layer ? 2021 : 2031, layer->layer_id);
+    Result rc = serviceDispatchIn(&g_viIApplicationDisplayService, layer->stray_layer ? 2031 : 2021, layer->layer_id);
 
     if (R_SUCCEEDED(rc)) {
         memset(layer, 0, sizeof(*layer));


### PR DESCRIPTION
`2021` is `CloseLayer`, while `2031` is `DestroyStrayLayer`. It used to be correct, but got swapped in [this commit](https://github.com/switchbrew/libnx/commit/4e7159ce026e162d1438f3bd25f4e49e9d3f3654) for some reason.