### PR TITLE
audren: expose frame event.

### DIFF
--- a/nx/include/switch/services/audren.h
+++ b/nx/include/switch/services/audren.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../types.h"
+#include "../kernel/event.h"
 #include "../audio/audio.h"
 #include "../sf/service.h"
 
@@ -323,6 +324,9 @@ void audrenExit(void);
 
 /// Gets the Service object for IAudioRenderer.
 Service* audrenGetServiceSession_AudioRenderer(void);
+
+/// Returns event that is signalled on new frame (autoclear=true).
+Event* audrenGetFrameEvent(void);
 
 void audrenWaitFrame(void);
 Result audrenGetState(u32* out_state);

--- a/nx/source/services/audren.c
+++ b/nx/source/services/audren.c
@@ -111,6 +111,10 @@ Service* audrenGetServiceSession_AudioRenderer(void) {
     return &g_audrenIAudioRenderer;
 }
 
+Event* audrenGetFrameEvent(void) {
+    return &g_audrenEvent;
+}
+
 static Result _audrenCmdGetHandle(Service* srv, Handle* handle_out, u32 cmd_id) {
     return serviceDispatch(srv, cmd_id,
         .out_handle_attrs = { SfOutHandleAttr_HipcCopy },


### PR DESCRIPTION
This exposes the frame event.

My use case for this is i want to be able to use wait multi for the audren event and my own cancel uevent.