### PR TITLE
Fix svcSetHeapSize note

### DIFF
--- a/nx/include/switch/kernel/svc.h
+++ b/nx/include/switch/kernel/svc.h
@@ -296,7 +296,7 @@ typedef enum {
 /**
  * @brief Set the process heap to a given size. It can both extend and shrink the heap.
  * @param[out] out_addr Variable to which write the address of the heap (which is randomized and fixed by the kernel)
- * @param[in] size Size of the heap, must be a multiple of 0x200000 and [2.0.0+] less than 0x100000000.
+ * @param[in] size Size of the heap, must be a multiple of 0x200000.
  * @return Result code.
  * @note Syscall number 0x01.
  */


### PR DESCRIPTION
So according to switchbrew it's 4GB, not 6 that was added in 2.0.0. 
And in Atmosphere code limit is 8 GB, not 6.

So there is a big incosistency here. Updated it to match 4 GB per switchbrew, but I bet it will bring into discussion this issue and we can figure out a correct answer for this note. It was 4 GB that was later changed to 6 and to 8, it was 6 from 2.0.0 and later changed to 8?

Original commit was wrong anyway because it lacked one zero to match 6GB.