### PR TITLE
Update TickCountInfo and IdleTickCount notes

### DIFF
--- a/nx/include/switch/kernel/svc.h
+++ b/nx/include/switch/kernel/svc.h
@@ -231,7 +231,7 @@ typedef enum {
     TickCountInfo_Core2 = 2,       ///< Tick count on core 2.
     TickCountInfo_Core3 = 3,       ///< Tick count on core 3.
 
-    TickCountInfo_ThreadCore = -1l, ///< Thread's current core.
+    TickCountInfo_Total = UINT64_MAX, ///< ThreadTickCount: Tick count on all cores, IdleTickCount: Thread's current core.
 } TickCountInfo;
 
 /// GetInfo InitialProcessIdRange Sub IDs.


### PR DESCRIPTION
InfoType_IdleTickCount can be used only with core currently used by thread calling svcGetInfo.
-1 is a shortcut to get ticks for current thread's core without choosing specific core number.

I am expecting that this PR will need to be changed with your guidance.

Per atmosphere source code:
- InfoType_IdleTickCount: 
  - https://github.com/Atmosphere-NX/Atmosphere/blob/c8e39a54d257bf9875ac852fc1521f046c968339/libraries/libmesosphere/source/svc/kern_svc_info.cpp#L223