### PR TITLE
correct internal consoleCls & consoleClearLine calls

### DIFF
--- a/nx/source/runtime/devices/console.c
+++ b/nx/source/runtime/devices/console.c
@@ -532,7 +532,7 @@ static ssize_t con_write(struct _reent *r,void *fd,const char *ptr, size_t len) 
 				if (escapeSeq.argIdx == 0 && !escapeSeq.hasArg) {
 					escapeSeq.args[0] = 0;
 				}
-				consoleCls(escapeSeq.args[0]);
+				consoleCls(escapeSeq.args[0] - '0');
 				escapeSeq.state = ESC_NONE;
 				break;
 			//---------------------------------------
@@ -542,7 +542,7 @@ static ssize_t con_write(struct _reent *r,void *fd,const char *ptr, size_t len) 
 				if (escapeSeq.argIdx == 0 && !escapeSeq.hasArg) {
 					escapeSeq.args[0] = 0;
 				}
-				consoleClearLine(escapeSeq.args[0]);
+				consoleClearLine(escapeSeq.args[0] - '0');
 				escapeSeq.state = ESC_NONE;
 				break;
 			//---------------------------------------
@@ -619,7 +619,7 @@ PrintConsole* consoleInit(PrintConsole* console) {
 
 	if (!console->consoleInitialised && console->renderer->init(console)) {
 		console->consoleInitialised = true;
-		consoleCls('2');
+		consoleCls(2);
 		return console;
 	}
 
@@ -749,7 +749,7 @@ void consolePrintChar(int c) {
 //---------------------------------------------------------------------------------
 void consoleClear(void) {
 //---------------------------------------------------------------------------------
-	consoleCls ('2');
+	consoleCls (2);
 }
 
 //---------------------------------------------------------------------------------


### PR DESCRIPTION
Pointed out by Antares, featured in AMS' Haze and my homebrew version, the screen would not properly be cleared since https://github.com/switchbrew/libnx/commit/b186ec08bc2553668334afad8aa9d0502e932145
