### PR TITLE
usb: include additional definitions from libusb

### DIFF
--- a/nx/include/switch/services/usb.h
+++ b/nx/include/switch/services/usb.h
@@ -228,6 +228,22 @@ enum usb_standard_request {
 };
 
 /// Imported from libusb, with changed names.
+enum usb_request_type {
+    USB_REQUEST_TYPE_STANDARD = (0x00 << 5),
+    USB_REQUEST_TYPE_CLASS = (0x01 << 5),
+    USB_REQUEST_TYPE_VENDOR = (0x02 << 5),
+    USB_REQUEST_TYPE_RESERVED = (0x03 << 5)
+};
+
+/// Imported from libusb, with changed names.
+enum usb_request_recipient {
+    USB_RECIPIENT_DEVICE = 0x00,
+    USB_RECIPIENT_INTERFACE = 0x01,
+    USB_RECIPIENT_ENDPOINT = 0x02,
+    USB_RECIPIENT_OTHER = 0x03
+};
+
+/// Imported from libusb, with changed names.
 enum usb_iso_sync_type {
     USB_ISO_SYNC_TYPE_NONE = 0,
     USB_ISO_SYNC_TYPE_ASYNC = 1,


### PR DESCRIPTION
This adds some type definitions from libusb that are useful for setting up HID interfaces using usb:ds