### PR TITLE
Fix wrong struct for BatteryChargeInfoFields

### DIFF
--- a/nx/include/switch/services/psm.h
+++ b/nx/include/switch/services/psm.h
@@ -73,6 +73,7 @@ typedef struct {
     u32 battery_charge_percentage;    ///< Raw battery charged capacity per cent-mille
     u32 battery_charge_milli_voltage; ///< Voltage average in mV
     u32 battery_age_percentage;       ///< Battery age per cent-mille
+    u32 unk_x2c;                      ///< It's the same value as charger_input_voltage_limit
     u32 usb_power_role;
     u32 usb_charger_type;
     u32 charger_input_voltage_limit;  ///< Charger and external device voltage limit in mV
@@ -81,7 +82,7 @@ typedef struct {
     bool controller_power_supply;
     bool otg_request;
     u8 reserved;
-    u8 unk_x40[0x14];
+    u8 unk_x44[0x10];
 } PsmBatteryChargeInfoFields;
 
 /// IPsmSession

--- a/nx/source/services/psm.c
+++ b/nx/source/services/psm.c
@@ -143,6 +143,14 @@ Result psmGetBatteryChargeInfoFields(PsmBatteryChargeInfoFields *out_fields) {
         if (R_SUCCEEDED(rc)) {
             memset(out_fields, 0, sizeof(*out_fields));
             memcpy(out_fields, &fields, sizeof(fields));
+            out_fields->reserved = fields.reserved;
+            out_fields->otg_request = fields.otg_request;
+            out_fields->controller_power_supply = fields.controller_power_supply;
+            out_fields->fast_battery_charging = fields.fast_battery_charging;
+            out_fields->charger_input_current_limit = fields.charger_input_current_limit;
+            out_fields->charger_input_voltage_limit = fields.charger_input_voltage_limit;
+            out_fields->usb_charger_type = fields.usb_charger_type;
+            out_fields->usb_power_role = fields.usb_power_role;
         }
         return rc;
     }


### PR DESCRIPTION
Just now checked that charger provided wrong values. From my old implementation of 17.0.0 update it looked different, i changed it to match what I had already few years ago.